### PR TITLE
Converted slot and slot-scope directives to v-slot in TableAuditLog.vue

### DIFF
--- a/src/components/TableAuditLog.vue
+++ b/src/components/TableAuditLog.vue
@@ -1,20 +1,74 @@
 <template>
   <div>
-    <q-table title="Audit logs" ref="table" color="primary" :data="logs" selection="none" :columns="columns" :filter="filter" row-key="_key" :pagination.sync="pagination"  @request="loadLogs" :loading="loading">
-      <template slot="top-right">
-        <q-select emit-value map-options :options="eventTypesOpts" v-model="filter.eventType" hint="Event" @input="updateFilters()" class="q-mr-sm" style="width: 150px"/>
-        <q-input v-model="filter.after" type="date" hint="From date" clearable @input="updateFilters()" class="q-mr-sm"/>
-        <q-input v-model="filter.before" type="date" hint="To date" clearable @input="updateFilters()" class="q-mr-sm"/>
-        <q-input v-model="filter.userEmail" type="text" hint="User email" clearable @input="updateFilters()" debounce="500"/>
+    <q-table
+      title="Audit logs"
+      ref="table"
+      color="primary"
+      :data="logs"
+      selection="none"
+      :columns="columns"
+      :filter="filter"
+      row-key="_key"
+      :pagination.sync="pagination"
+      @request="loadLogs"
+      :loading="loading"
+    >
+      <template #top-right>
+        <q-select
+          emit-value
+          map-options
+          :options="eventTypesOpts"
+          v-model="filter.eventType"
+          hint="Event"
+          @input="updateFilters()"
+          class="q-mr-sm"
+          style="width: 150px"
+        />
+        <q-input
+          v-model="filter.after"
+          type="date"
+          hint="From date"
+          clearable
+          @input="updateFilters()"
+          class="q-mr-sm"
+        />
+        <q-input
+          v-model="filter.before"
+          type="date"
+          hint="To date"
+          clearable
+          @input="updateFilters()"
+          class="q-mr-sm"
+        />
+        <q-input
+          v-model="filter.userEmail"
+          type="text"
+          hint="User email"
+          clearable
+          @input="updateFilters()"
+          debounce="500"
+        />
       </template>
-      <q-td slot="body-cell-timestamp" slot-scope="props" :props="props">
-        {{ niceTimestamp(props.value) }}
-      </q-td>
-      <q-td slot="body-cell-data" slot-scope="props" :props="props">
-        <q-btn v-if="props.value" flat icon="info"  @click="showLogData(props)"/>
-      </q-td>
+      <template #body-cell-timestamp="props">
+        <q-td :props="props">
+          {{ niceTimestamp(props.value) }}
+        </q-td>
+      </template>
+      <template #body-cell-data="props">
+        <q-td :props="props">
+          <q-btn
+            v-if="props.value"
+            flat
+            icon="info"
+            @click="showLogData(props)"
+          />
+        </q-td>
+      </template>
     </q-table>
-    <q-dialog v-model="logDataModal" :content-css="{minWidth: '50vw'}">
+    <q-dialog
+      v-model="logDataModal"
+      :content-css="{minWidth: '50vw'}"
+    >
       <q-card>
         <q-card-section class="row items-center">
           <div class="text-h6">
@@ -23,7 +77,13 @@
             <span v-if="logDataType == 'answers'">Answers:</span>
           </div>
           <q-space />
-          <q-btn icon="close" flat round dense v-close-popup />
+          <q-btn
+            icon="close"
+            flat
+            round
+            dense
+            v-close-popup
+          />
         </q-card-section>
 
         <q-card-section>
@@ -33,14 +93,21 @@
             </pre>
           </div>
           <div v-if="logDataType == 'healthStoreData'">
-            <div v-for="(hd, index) in logDataModalContent.healthData" :key="index" class="q-ma-md">
+            <div
+              v-for="(hd, index) in logDataModalContent.healthData"
+              :key="index"
+              class="q-ma-md"
+            >
               Start: {{ niceTimestamp(hd.startDate )}}<br />
               End: {{ niceTimestamp(hd.endDate) }}<br />
               Value: {{ hd.value }} {{ hd.unit }}
             </div>
           </div>
           <div v-if="logDataType == 'answers'">
-            <div v-for="(answer, index) in logDataModalContent.responses" :key="index">
+            <div
+              v-for="(answer, index) in logDataModalContent.responses"
+              :key="index"
+            >
               <p class="q-title">
                 {{ answer.questionText }}
               </p>
@@ -51,7 +118,10 @@
                 {{ answer.answer.answerText }}
               </p>
               <div v-if="answer.questionType == 'multiChoice'">
-                <p v-for="(subanswer, index1) in answer.answer" :key="index1">
+                <p
+                  v-for="(subanswer, index1) in answer.answer"
+                  :key="index1"
+                >
                   {{ subanswer.answerText }}
                 </p>
               </div>
@@ -196,7 +266,7 @@ export default {
   border-bottom-color: black;
 }
 .q-table__bottom {
-  border-top:  1px solid black;
+  border-top: 1px solid black;
 }
 
 .q-table__top {


### PR DESCRIPTION
`slot` and `slot-scope` directives are deprecated, and will be removed in Vue 3. Replacing them is the single directive `v-slot`, which can only be attributed to `<template>` and component elements.  For this reason, the `<q-td>` elements are now surrounded by `<template>` tags.

Shorthand for `v-slot` (#) is used.

Regards issue #13 