### PR TITLE
Remaining fixes of TableUsers.vue

### DIFF
--- a/src/components/TableAuditLog.vue
+++ b/src/components/TableAuditLog.vue
@@ -211,7 +211,7 @@ export default {
           userEmail: params.filter.userEmail,
           sortDirection: params.pagination.descending ? 'DESC' : 'ASC',
           offset: (params.pagination.page - 1) * params.pagination.rowsPerPage,
-          count: params.pagination.rowsPerPage
+          rowsPerPage: params.pagination.rowsPerPage
         }
         this.pagination.rowsNumber = await API.getLogs(true, queryParams)
         this.logs = await API.getLogs(false, queryParams)

--- a/src/components/TableUsers.vue
+++ b/src/components/TableUsers.vue
@@ -104,7 +104,6 @@ export default {
       })
     },
     async deleteUser (user) {
-      console.log('USER: ' + user.email)
       this.$q.dialog({
         title: 'Delete User',
         color: 'warning',
@@ -114,15 +113,20 @@ export default {
       }).onOk(async () => {
         try {
           if (user.role === 'participant') {
-            // Get participant key
-            let partKey = await API.getOneParticipant(user._key)
-            await API.deleteParticipant(partKey._key)
+            // Gets Participant from User's userkey
+            let participant = await API.getOneParticipant(user.userkey)
+            // Deletes entry in Participants and the corresponding one in Users
+            let partKey = participant._key
+            await API.deleteParticipant(partKey)
           } else {
-            await API.deleteUser(user._key)
+            await API.deleteUser(user.userkey)
           }
           this.users.splice(user, 1)
           this.$q.notify('User ' + user.email + ' deleted')
-          this.loadUsers()
+          this.loadUsers({
+            pagination: this.pagination,
+            filter: this.filter
+          })
         } catch (err) {
           console.debug(err)
           this.$q.notify({

--- a/src/components/TableUsers.vue
+++ b/src/components/TableUsers.vue
@@ -106,7 +106,7 @@ export default {
           userEmail: params.filter.userEmail,
           sortDirection: params.pagination.descending ? 'DESC' : 'ASC',
           offset: (params.pagination.page - 1) * params.pagination.rowsPerPage,
-          count: params.pagination.rowsPerPage
+          rowsPerPage: params.pagination.rowsPerPage
         }
         this.pagination.rowsNumber = await API.getAllUsers(true, queryParams)
         this.users = await API.getAllUsers(false, queryParams)

--- a/src/components/TableUsers.vue
+++ b/src/components/TableUsers.vue
@@ -10,6 +10,7 @@
       row-key="_key"
       @request="loadUsers"
     >
+      <!-- Change row-key="_key" when it changes in the database (to be independent from ArangoDB) -->
       <template #top-right>
         <q-select
           emit-value
@@ -40,9 +41,6 @@
           />
         </q-td>
       </template>
-      <!-- Change row-key="_key" when it changes in the database (to be independent from ArangoDB) -->
-      <!-- Add loading after you add filters and sorting -->
-      <!-- INSERT <q-td> element (from TableAuditLog.vue) to include the delete button -->
     </q-table>
   </div>
 </template>
@@ -64,14 +62,11 @@ export default {
       ],
       filter: {
         userEmail: undefined,
-        roleType: 'all'
+        roleType: 'All'
       },
-      roleTypesOpts: [],
+      roleTypesOpts: ['All', 'admin', 'researcher', 'participant'],
       loading: false
     }
-  },
-  async created () {
-    this.getRoleTypes()
   },
   async mounted () {
     this.loadUsers({
@@ -80,29 +75,12 @@ export default {
     })
   },
   methods: {
-    async getRoleTypes () {
-      try {
-        let types = await API.getRoleTypes()
-        if (types) {
-          this.roleTypesOpts = types.map(evt => {
-            return { label: evt, value: evt }
-          })
-        }
-        this.roleTypesOpts.unshift({ label: 'All', value: 'all' })
-      } catch (err) {
-        this.$q.notify({
-          color: 'negative',
-          message: 'Cannot retrieve role types',
-          icon: 'report_problem'
-        })
-      }
-    },
     async loadUsers (params) {
       this.loading = true
       this.pagination = params.pagination
       try {
         let queryParams = {
-          roleType: params.filter.roleType === 'all' ? undefined : params.filter.roleType,
+          roleType: params.filter.roleType === 'All' ? undefined : params.filter.roleType,
           userEmail: params.filter.userEmail,
           sortDirection: params.pagination.descending ? 'DESC' : 'ASC',
           offset: (params.pagination.page - 1) * params.pagination.rowsPerPage,


### PR DESCRIPTION
Fixed the comments from the review of the previous pull request.

* deleteUser function in TableUsers.vue now deletes participants correctly
* Created a static role types list as opposed to fetching it from the API
* Changed name of `count` to `rowsPerPage` so that it's named this way everywhere

Related to #13 