### PR TITLE
Mixin that takes study titles object and returns the first non-empty string value

### DIFF
--- a/src/mixins/getLocalTitleMixin.js
+++ b/src/mixins/getLocalTitleMixin.js
@@ -1,6 +1,9 @@
 export const getLocalTitle = {
   methods: {
     // Iterates through the study titles and returns the first with a non-empty string
-    getFirstTitle (obj) { for (const key in obj) if (obj[key] !== '') return obj[key] }
+    getFirstTitle (obj) {
+      if (obj.en !== '') return obj.en
+      else for (const key in obj) if (obj[key] !== '') return obj[key]
+    }
   }
 }

--- a/src/mixins/getLocalTitleMixin.js
+++ b/src/mixins/getLocalTitleMixin.js
@@ -1,0 +1,6 @@
+export const getLocalTitle = {
+  methods: {
+    // Iterates through the study titles and returns the first with a non-empty string
+    getFirstTitle (obj) { for (const key in obj) if (obj[key] !== '') return obj[key] }
+  }
+}

--- a/src/pages/StudyMonitor.vue
+++ b/src/pages/StudyMonitor.vue
@@ -2,7 +2,7 @@
   <q-page>
     <q-toolbar class="bg-secondary text-white">
       <q-toolbar-title>
-        Statistics about {{ studyDesign.generalities.title }}
+        Statistics about <strong>{{ niceTitle(studyDesign.generalities.title) }}</strong>
       </q-toolbar-title>
       <q-btn class="float-right q-mr-md" round color="black" icon="close" @click="$router.push('/researcher')"/>
     </q-toolbar>
@@ -58,6 +58,21 @@ export default {
         message: 'Cannot retrieve the study description. ' + err.message,
         icon: 'report_problem'
       })
+    }
+  },
+  methods: {
+    niceTitle (titles) {
+      let titleString = ''
+      let firstItem = true
+      let studyTitles = Object.entries(titles)
+
+      for (const [lang, val] of studyTitles) {
+        if (val !== '') {
+          titleString += (firstItem ? '' : ', ') + `${lang}: ${val}`
+          firstItem = false
+        }
+      }
+      return titleString
     }
   }
 }

--- a/src/pages/StudyMonitor.vue
+++ b/src/pages/StudyMonitor.vue
@@ -28,10 +28,12 @@
 import API from '../modules/API.js'
 import StudyStats from '../components/StudyStats'
 import StudySummary from '../components/StudySummary'
+import { getLocalTitle } from '../mixins/getLocalTitleMixin'
 
 export default {
   name: 'StudyMonitor',
   props: ['studyKey'],
+  mixins: [getLocalTitle],
   components: {
     StudyStats, StudySummary
   },
@@ -62,18 +64,10 @@ export default {
   },
   methods: {
     niceTitle (titles) {
-      let titleString = ''
-      let firstItem = true
-      let studyTitles = Object.entries(titles)
-
-      for (const [lang, val] of studyTitles) {
-        if (val !== '') {
-          titleString += (firstItem ? '' : ', ') + `${lang}: ${val}`
-          firstItem = false
-        }
-      }
-      return titleString
+      // Sends study titles object as a param and returns a single title
+      return this.getFirstTitle(titles)
     }
   }
 }
+
 </script>


### PR DESCRIPTION
Since English is always the first item, the `en` value will be returned if it's not an empty string. If the English string value is empty, e.g. if the defined study language is only Swedish, the object's first item (`en`) will have an empty value – which the mixin function then skips over in order to return the next non-empty string value (`sv`).

The mixin is imported in StudyMonitor.vue and used in the `niceTitle()` method, which is called in the HTML code.

Alternatively, the mixin function could be called directly in the HTML code.