### PR TITLE
Progression tab

### DIFF
--- a/src/components/researcher/studymonitor/ParticipantActivityLog.vue
+++ b/src/components/researcher/studymonitor/ParticipantActivityLog.vue
@@ -1,0 +1,190 @@
+<template>
+  <div class="q-pa-md">
+    <q-table title="Activity log" :rows="tasks" selection="none" :columns="columns" row-key="_key"
+      v-model:pagination="pagination" @request="loadTasksSummary" :loading="loadingTasksSummary">
+      <template #body-cell-data="props">
+        <q-td :props="props">
+          <q-btn v-if="!props.row.discarded" flat icon="open_in_new" @click="showTaskData(props.row)" />
+        </q-td>
+      </template>
+      <template #body-cell-formName="props">
+        <q-td :props="props">
+          {{ showTaskName(props.row.taskId) }}
+        </q-td>
+      </template>
+      <template #body-cell-completedTS="props">
+        <q-td :props="props">
+          <div v-if="props.row.discarded">{{ niceTimestamp(props.row.createdTS) }}</div>
+          <div v-else>{{ niceTimestamp(props.row.summary?.completedTS) }}</div>
+        </q-td>
+      </template>
+      <template #body-cell-summary="props">
+        <q-td :props="props">
+          <div v-if="props.row.discarded">Discarded</div>
+          <div v-else v-html="taskSummaryToString(props.row.summary, props.row.taskType)"></div>
+        </q-td>
+      </template>
+    </q-table>
+  </div>
+</template>
+
+<script>
+import API from '@shared/API.js'
+import { bestLocale } from '@mixins/bestLocale'
+import { date } from 'quasar'
+
+import AnswersDialog from './taskResultsDialogs/AnswersDialog.vue'
+import DrawingDialog from './taskResultsDialogs/DrawingDialog.vue'
+import FingerTappingDialog from './taskResultsDialogs/FingerTappingDialog.vue'
+import JStyleDialog from './taskResultsDialogs/JStyleDialog.vue'
+
+export default {
+  name: 'ParticipantActivityLog',
+  props: ['studyKey', 'userKey', 'studyDescription'],
+  mixins: [bestLocale],
+  data () {
+    return {
+      tasks: [],
+      columns: [
+        { name: 'data', required: false, label: '', align: 'center', field: 'data', sortable: false },
+        { name: 'formName', required: true, label: 'Task', align: 'center', field: 'formName' },
+        { name: 'summary', required: true, label: 'Summary', align: 'center', field: 'summary', sortable: false },
+        { name: 'completedTS', required: true, label: 'Completed', align: 'center', field: 'completedTS', sortable: false }
+      ],
+      pagination: { page: 1, rowsPerPage: 20, rowsNumber: 0 },
+      loadingTasksSummary: false
+    }
+  },
+  created () {
+    this.loadTasksSummary()
+  },
+  methods: {
+    niceTimestamp (timeStamp) {
+      return date.formatDate(timeStamp, 'YYYY-MM-DD HH:mm:ss')
+    },
+    firstLetterUpperCase (str) {
+      return str.charAt(0).toUpperCase() + str.slice(1)
+    },
+    /**
+     * Formats the task name in a readable string
+     */
+    showTaskName (taskId) {
+      const tasks = this.studyDescription?.tasks
+      if (!tasks) return 'Unknown task'
+      const task = tasks.find(t => t.id === taskId)
+      if (!task) return 'Unknown task'
+      if (task.customTitle) {
+        return this.getBestLocale(task.customTitle)
+      }
+      const taskType = task.type
+      if (taskType === 'form' && task.formName) return this.getBestLocale(task.formName)
+      return this.firstLetterUpperCase(taskType)
+    },
+    /**
+     * Loads the tasks summary table for that participant
+     */
+    async loadTasksSummary (params) {
+      this.loadingTasksSummary = true
+      if (params) this.pagination = params.pagination
+      const offset = (this.pagination.page - 1) * this.pagination.rowsPerPage
+      const count = this.pagination.rowsPerPage
+      try {
+        const resp = await API.getTasksResults(this.studyKey, this.userKey, null, offset, count)
+        this.tasks = resp.subset
+        this.pagination.rowsNumber = resp.totalCount
+      } catch (err) {
+        this.$q.notify({
+          color: 'negative',
+          message: 'Cannot retrieve tasks',
+          icon: 'report_problem'
+        })
+      }
+      this.loadingTasksSummary = false
+    },
+    /**
+     * Opens a dialog with the task results details
+     */
+    async showTaskData (taskResult) {
+      let component
+      if (taskResult.taskType === 'form') component = AnswersDialog
+      if (taskResult.taskType === 'drawing') component = DrawingDialog
+      if (taskResult.taskType === 'fingerTapping') component = FingerTappingDialog
+      if (taskResult.taskType === 'jstyle') component = JStyleDialog
+      this.$q.dialog({
+        // component loaded into the dialog
+        component,
+        // props forwarded to custom component
+        componentProps: {
+          taskResult,
+          taskName: this.showTaskName(taskResult.taskId)
+        }
+      })
+    },
+    /**
+     * Formats the task summary to a readable string
+     */
+    taskSummaryToString (summary, taskType) {
+      let retString = ''
+      if (taskType === 'form') {
+        retString += 'Answered: ' + summary.answered + ' of ' + summary.asked
+        for (const prop in summary) {
+          if (prop !== 'answered' &&
+            prop !== 'asked' &&
+            prop !== 'startedTS' &&
+            prop !== 'completedTS') {
+            if (typeof summary[prop] === 'string') {
+              retString += '<br>' + this.firstLetterUpperCase(prop) + ': ' + summary[prop]
+            } else if (typeof summary[prop] === 'number') {
+              retString += '<br>' + this.firstLetterUpperCase(prop) + ': ' + summary[prop].toFixed(0)
+            }
+          }
+        }
+      } else if (taskType === 'dataQuery') {
+        retString += 'Type: ' + summary.type
+      } else if (taskType === 'drawing') {
+        retString += 'Square deviation: ' + summary.totalVariabilitySquare.toFixed(0) + '<br>'
+        retString += 'Spiral deviation: ' + summary.totalVariabilitySpiral.toFixed(0) + '<br>'
+      } else if (taskType === 'fingerTapping') {
+        retString += 'Taps count: ' + summary.tappingCount + '<br>'
+      } else if (taskType === 'vocalization') {
+        for (const phase of summary.phases) {
+          const timeDiffSecs = (new Date(phase.completedTS).getTime() - new Date(phase.startedTS).getTime()) / 1000
+          retString += 'Vowel ' + phase.vocal.toUpperCase() + ' : ' + Math.round(timeDiffSecs) + ' sec <br>'
+        }
+      } else if (taskType === 'holdPhone') {
+        retString += 'Resting accel variance L ' + summary.resting.left.accelerationVariance.toFixed(2)
+        retString += ' - R ' + summary.resting.right.accelerationVariance.toFixed(2) + '<br>'
+        retString += 'Postural accel variance L ' + summary.postural.left.accelerationVariance.toFixed(2)
+        retString += ' - R ' + summary.postural.right.accelerationVariance.toFixed(2) + '<br>'
+        retString += 'Kinetic accel variance L ' + summary.postural.left.accelerationVariance.toFixed(2)
+        retString += ' - R ' + summary.kinetic.right.accelerationVariance.toFixed(2)
+      } else if (taskType === 'tugt') {
+        retString += 'Duration: ' + (summary.durationMs / 1000).toFixed(0) + ' sec'
+      } else if (taskType === 'miband3') {
+        retString += 'From: ' + summary.firstTS.slice(0, 10) + ' to: ' + summary.lastTS.slice(0, 10)
+      } else if (taskType === 'peakFlow') {
+        retString += 'PEF Max: ' + summary.pefMax
+      } else if (taskType === 'po60') {
+        retString += 'SPO2: ' + summary.spo2 + ', HR: ' + summary.hr
+      } else if (taskType === 'position') {
+        retString += 'Location: ' + summary.location + '<br>'
+        retString += 'Weather: ' + summary.weather + '<br>'
+        retString += 'Temperature: ' + summary.temperature + '<br>'
+        retString += 'Air quality: ' + summary.aqi
+      } else if (taskType === 'smwt') {
+        retString += 'Distance: ' + summary.distance.toFixed(0) + 'm'
+      } else if (taskType === 'jstyle') {
+        if (summary.activitySummary && summary.activitySummary.length > 0) {
+          for (let i = 0; i < summary.activitySummary.length; i++) {
+            if (i > 0) retString += '<br>'
+            retString += 'Date: ' + summary.activitySummary[i].date.slice(0, 10) + ' - Steps: ' + summary.activitySummary[i].steps
+          }
+        } else {
+          retString += 'From: ' + summary.firstTS.slice(0, 10) + ' to ' + summary.lastTS.slice(0, 10)
+        }
+      }
+      return retString
+    }
+  }
+}
+</script>

--- a/src/components/researcher/studymonitor/ParticipantSummaryPage.vue
+++ b/src/components/researcher/studymonitor/ParticipantSummaryPage.vue
@@ -12,7 +12,7 @@
         <div v-if="participant.dateOfBirth || participant.sex || participant.weight || participant.height"
           class="patient-meta">
           <span v-if="participant.dateOfBirth">{{ new Date(participant.dateOfBirth).toLocaleDateString('sv-SE')
-          }}</span>
+            }}</span>
           <span v-if="participant.dateOfBirth && participant.sex"> · </span>
           <span v-if="participant.sex">{{ participant.sex }}</span>
           <template v-if="participant.weight || participant.height">
@@ -42,13 +42,14 @@
         class="tab-nav-tabs q-px-lg" style="min-height: 56px">
         <q-tab name="progression" icon="ssid_chart" label="Progression" />
         <q-tab name="activity" icon="list_alt" label="Activity Log" />
-        <q-tab name="notes" icon="sticky_note_2" label="Clinical Notes" disable />
+        <q-tab name="notes" icon="sticky_note_2" label="Clinical Notes" disable/>
         <q-tab name="external" icon="link" label="External Systems" disable />
       </q-tabs>
     </div>
 
     <!-- Tab content -->
-    <q-tab-panels v-model="activeTab" animated class="tab-panels-bg">
+    <!-- keep-alive preserves panel state (e.g. progression chart, selected task) when switching tabs -->
+    <q-tab-panels v-model="activeTab" animated keep-alive class="tab-panels-bg">
 
       <!-- Progression -->
       <q-tab-panel name="progression" class="q-pa-none">
@@ -100,12 +101,11 @@
           </div>
         </div>
 
-        <div class="progression-tab-wrapper q-px-lg q-pb-lg">
+        <div class="q-px-lg q-pb-lg">
           <div class="progression-content">
             <div class="text-h6 q-mb-sm">Progression</div>
-            <q-select square outlined bg-color="white" v-model="progrSelectedTasks"
-              :options="progrTaskSelectOptions" label="Select task"
-              :popup-content-style="{ maxHeight: '260px' }" />
+            <q-select square outlined bg-color="white" v-model="progrSelectedTasks" :options="progrTaskSelectOptions"
+              label="Select task" :popup-content-style="{ maxHeight: '260px' }" />
             <div v-show="!progrSelectedTasks" class="text-grey-7 q-mt-md">
               No task selected
             </div>
@@ -397,19 +397,12 @@ export default {
 }
 
 /* ── Progression tab ───────────────────────────────────────────────── */
-.progression-tab-wrapper {
-  display: flex;
-  justify-content: center;
-}
-
 .progression-content {
   width: 100%;
-  max-width: 1100px;
 }
 
 .progression-charts {
   max-width: 760px;
-  margin: 0 auto;
 }
 
 .patient-toolbar {

--- a/src/components/researcher/studymonitor/ParticipantSummaryPage.vue
+++ b/src/components/researcher/studymonitor/ParticipantSummaryPage.vue
@@ -42,7 +42,7 @@
         class="tab-nav-tabs q-px-lg" style="min-height: 56px">
         <q-tab name="progression" icon="ssid_chart" label="Progression" />
         <q-tab name="activity" icon="list_alt" label="Activity Log" />
-        <q-tab name="notes" icon="sticky_note_2" label="Clinical Notes" />
+        <q-tab name="notes" icon="sticky_note_2" label="Notes" />
       </q-tabs>
     </div>
 

--- a/src/components/researcher/studymonitor/ParticipantSummaryPage.vue
+++ b/src/components/researcher/studymonitor/ParticipantSummaryPage.vue
@@ -103,15 +103,59 @@
 
         <div class="q-px-lg q-pb-lg">
           <div class="progression-content">
-            <div class="text-h6 q-mb-sm">Progression</div>
-            <q-select square outlined bg-color="white" v-model="progrSelectedTasks" :options="progrTaskSelectOptions"
-              label="Select task" :popup-content-style="{ maxHeight: '260px' }" />
-            <div v-show="!progrSelectedTasks" class="text-grey-7 q-mt-md">
-              No task selected
+            <div class="row items-center q-mb-md">
+              <div class="text-h6 col">Progression</div>
+              <q-btn outline color="secondary" icon="add" label="Add chart" no-caps
+                :disable="progrSlots.length >= 4" @click="addSlot" />
             </div>
-            <div class="progression-charts q-mt-md">
-              <TaskProgressionCharts :studyDescription="studyDescription" :userKey="userKey"
-                :selectedTasks="progrSelectedTasks" />
+
+            <div class="row q-col-gutter-md">
+              <div v-for="(slot, idx) in progrSlots" :key="slot.id" :class="slotColClass">
+                <div class="slot-wrapper">
+                  <div v-if="progrSlots.length > 1" class="row no-wrap items-center q-mb-xs">
+                    <q-space />
+                    <q-btn flat round dense size="sm" icon="close" color="grey-6"
+                      aria-label="Remove chart" @click="removeSlot(idx)" />
+                  </div>
+
+                  <!-- Metric picker rows: primary + optional overlays -->
+                  <div v-for="(metric, mIdx) in slot.metrics" :key="mIdx" class="metric-row q-mb-sm">
+                    <div class="row q-col-gutter-sm items-center">
+                      <div class="col-12 col-md">
+                        <q-select dense outlined bg-color="white"
+                          :model-value="taskOptionFromTaskValue(metric.taskValue)"
+                          :options="progrTaskSelectOptions"
+                          :label="mIdx === 0 ? 'Task' : 'Compare with task'"
+                          :popup-content-style="{ maxHeight: '260px' }"
+                          @update:model-value="setMetricTask(idx, mIdx, $event)" />
+                      </div>
+                      <div class="col-12 col-md">
+                        <q-select dense outlined bg-color="white"
+                          :model-value="metric.signalKey"
+                          :options="signalOptionsForTaskValue(metric.taskValue)"
+                          label="Signal" emit-value map-options
+                          :popup-content-style="{ maxHeight: '260px' }"
+                          :disable="!metric.taskValue"
+                          @update:model-value="setMetricSignal(idx, mIdx, $event)" />
+                      </div>
+                      <div v-if="slot.metrics.length > 1" class="col-auto">
+                        <q-btn flat round dense size="sm" icon="close" color="grey-6"
+                          aria-label="Remove metric" @click="removeMetric(idx, mIdx)" />
+                      </div>
+                    </div>
+                  </div>
+
+                  <q-btn flat dense no-caps size="sm" color="secondary" icon="add"
+                    :disable="!canAddMetric(slot)"
+                    label="Compare with another metric"
+                    @click="addMetric(idx)" />
+
+                  <div class="progression-charts q-mt-md">
+                    <TaskProgressionCharts :studyDescription="studyDescription" :userKey="userKey"
+                      :slot-config="slot" :form-defs="formDefs" />
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -138,6 +182,10 @@ import { taskTypeToString } from '@i18n/utils'
 import TaskProgressionCharts from './TaskProgressionCharts.vue'
 import PatientTrends from './PatientTrends.vue'
 import ParticipantActivityLog from './ParticipantActivityLog.vue'
+import { listSignalsForTask, describeSignal } from './signalCatalog.js'
+
+// Upper bound on how many metrics can be compared in a single chart slot
+const MAX_METRICS_PER_SLOT = 2
 
 export default {
   name: 'ParticipantSummaryPage',
@@ -155,7 +203,16 @@ export default {
 
       // for progression charts:
       progrTaskSelectOptions: [],
-      progrSelectedTasks: null,
+      // 1–4 chart slots. Each slot has 1–4 metrics; each metric is a
+      // (taskValue, signalKey) pair. The first metric is the primary;
+      // additional metrics overlay as extra lines/datasets.
+      progrSlots: [],
+      // Form definitions indexed by taskId, preloaded so the signal
+      // picker can resolve form signal labels synchronously.
+      formDefs: {},
+      // Monotonic id used as :key on each slot to keep Vue's vdom stable
+      // when slots are added/removed.
+      nextSlotId: 1,
 
       // trend data populated by ParticipantTrendsBar via @trendsLoaded
       allTrendData: {},
@@ -171,6 +228,17 @@ export default {
   computed: {
     availableStatTrends () {
       return this.availableTrends.filter(k => this.allTrendData[k])
+    },
+    slotColClass () {
+      // Single chart fills the row; 2–4 charts each take half on desktop
+      // (col-md-6) and stack on narrow viewports (col-12).
+      return this.progrSlots.length === 1 ? 'col-12' : 'col-12 col-md-6'
+    },
+    slotStorageKey () {
+      // v2 schema (slot = { metrics: [{taskValue, signalKey}] }). v1 keys
+      // remain in localStorage but are ignored — users will see one empty
+      // slot first time after the upgrade.
+      return `progr-slots-v2-${this.studyKey}-${this.userKey}`
     },
     // Display-ready configs for the 4 selected stat cards
     statCardDefs () {
@@ -235,6 +303,23 @@ export default {
         }
       }
       this.progrTaskSelectOptions = taskOptions
+
+      // Preload form definitions so the signal-picker can list signals
+      // synchronously when the user opens a form's signal dropdown.
+      const formTasks = (this.studyDescription.tasks || []).filter(t => t.type === 'form')
+      await Promise.all(formTasks.map(async (t) => {
+        try {
+          const def = await API.getForm(t.formKey)
+          if (def) this.formDefs[t.id] = def
+        } catch (err) {
+          console.warn('Could not preload form definition', t.id, err)
+        }
+      }))
+
+      // Restore previously chosen slots for this (study × patient).
+      // Tasks/signals that no longer exist are reset to empty silently.
+      const loaded = this._loadSlots()
+      this.progrSlots = (loaded && loaded.length) ? loaded : [this._emptySlot()]
     } catch (err) {
       console.error(err)
       this.$q.notify({
@@ -242,6 +327,14 @@ export default {
         message: 'Cannot retrieve study plan',
         icon: 'report_problem'
       })
+    }
+  },
+  watch: {
+    progrSlots: {
+      handler () {
+        this._saveSlots()
+      },
+      deep: true
     }
   },
   methods: {
@@ -291,6 +384,170 @@ export default {
      */
     closeTab () {
       window.close()
+    },
+
+    // ── Slot / metric helpers ─────────────────────────────────────────
+    _emptyMetric () {
+      return { taskValue: null, signalKey: null }
+    },
+    _emptySlot () {
+      return { id: `slot-${this.nextSlotId++}`, metrics: [this._emptyMetric()] }
+    },
+    addSlot () {
+      if (this.progrSlots.length >= 4) return
+      this.progrSlots.push(this._emptySlot())
+    },
+    removeSlot (idx) {
+      if (this.progrSlots.length <= 1) return
+      this.progrSlots.splice(idx, 1)
+    },
+    addMetric (slotIdx) {
+      const slot = this.progrSlots[slotIdx]
+      if (!slot || !this.canAddMetric(slot)) return
+      const newSlot = { ...slot, metrics: [...slot.metrics, this._emptyMetric()] }
+      this.progrSlots.splice(slotIdx, 1, newSlot)
+    },
+    removeMetric (slotIdx, mIdx) {
+      const slot = this.progrSlots[slotIdx]
+      if (!slot || slot.metrics.length <= 1) return
+      const metrics = slot.metrics.slice()
+      metrics.splice(mIdx, 1)
+      this.progrSlots.splice(slotIdx, 1, { ...slot, metrics })
+    },
+    async setMetricTask (slotIdx, mIdx, taskOpt) {
+      const slot = this.progrSlots[slotIdx]
+      if (!slot) return
+
+      if (!taskOpt) {
+        this._patchMetric(slotIdx, mIdx, this._emptyMetric())
+        return
+      }
+
+      const taskValue = { type: taskOpt.value.type, ids: taskOpt.value.ids.slice() }
+
+      // if preload didn't complete (or failed) for
+      // this form, fetch its definition now so the signal picker is
+      // never empty when a real form is selected.
+      if (taskValue.type === 'form') {
+        await this._ensureFormDef(taskValue.ids[0])
+      }
+
+      const sigOpts = this.signalOptionsForTaskValue(taskValue)
+      // Auto-select the signal when there's exactly one, avoids the
+      // friction of a second click for single-signal forms like Pain Level.
+      const autoSignal = sigOpts.length === 1 ? sigOpts[0].value : null
+
+      this._patchMetric(slotIdx, mIdx, { taskValue, signalKey: autoSignal })
+    },
+    _patchMetric (slotIdx, mIdx, newMetric) {
+      const slot = this.progrSlots[slotIdx]
+      if (!slot) return
+      const metrics = slot.metrics.slice()
+      metrics.splice(mIdx, 1, newMetric)
+      this.progrSlots.splice(slotIdx, 1, { ...slot, metrics })
+    },
+    async _ensureFormDef (taskId) {
+      if (this.formDefs[taskId]) return this.formDefs[taskId]
+      const task = (this.studyDescription.tasks || []).find(t => t.id === parseInt(taskId))
+      if (!task || !task.formKey) return null
+      try {
+        const def = await API.getForm(task.formKey)
+        if (def) this.formDefs[taskId] = def
+        return def
+      } catch (err) {
+        console.warn('Could not load form definition', taskId, err)
+        return null
+      }
+    },
+    setMetricSignal (slotIdx, mIdx, signalKey) {
+      const slot = this.progrSlots[slotIdx]
+      if (!slot) return
+      const old = slot.metrics[mIdx]
+      const metrics = slot.metrics.slice()
+      metrics.splice(mIdx, 1, { ...old, signalKey })
+      this.progrSlots.splice(slotIdx, 1, { ...slot, metrics })
+    },
+    canAddMetric (slot) {
+      if (!slot || slot.metrics.length >= MAX_METRICS_PER_SLOT) return false
+      // Only allow adding a comparison once the primary metric is fully
+      const primary = slot.metrics[0]
+      if (!primary || !primary.taskValue || !primary.signalKey) return false
+      // The "all subscales (trends)" view takes over the whole slot —
+      // overlays are not visually meaningful there.
+      if (this._isExclusivePresentation(primary.signalKey)) return false
+      return true
+    },
+    _isExclusivePresentation (signalKey) {
+      return signalKey === '__alltrends'
+    },
+
+    // Picker-data helpers for the signal picker
+    taskOptionFromTaskValue (taskValue) {
+      if (!taskValue) return null
+      return this.progrTaskSelectOptions.find(o =>
+        o.value.type === taskValue.type && o.value.ids[0] === taskValue.ids[0]
+      ) || null
+    },
+    signalOptionsForTaskValue (taskValue) {
+      if (!taskValue) return []
+      const formDef = taskValue.type === 'form' ? this.formDefs[taskValue.ids[0]] : null
+      const keys = listSignalsForTask(taskValue.type, formDef)
+      return keys.map(k => {
+        const desc = describeSignal(taskValue.type, k, formDef)
+        return { label: this._resolveLocale(desc.name) || k, value: k }
+      })
+    },
+    _resolveLocale (val) {
+      if (!val) return ''
+      if (typeof val === 'string') return val
+      return this.getBestLocale(val) || ''
+    },
+
+    // Slot persistence (per study and patient)
+    _saveSlots () {
+      if (!this.studyKey || !this.userKey) return
+      try {
+        const serialisable = this.progrSlots.map(slot => ({
+          metrics: slot.metrics.map(m => (m && m.taskValue)
+            ? { taskType: m.taskValue.type, taskIds: m.taskValue.ids.slice(), signalKey: m.signalKey || null }
+            : null)
+        }))
+        localStorage.setItem(this.slotStorageKey, JSON.stringify(serialisable))
+      } catch {}
+    },
+    _loadSlots () {
+      try {
+        const raw = localStorage.getItem(this.slotStorageKey)
+        if (!raw) return null
+        const parsed = JSON.parse(raw)
+        if (!Array.isArray(parsed) || !parsed.length) return null
+        return parsed.slice(0, 4).map(s => {
+          const metrics = []
+          for (const m of (s.metrics || []).slice(0, MAX_METRICS_PER_SLOT)) {
+            if (!m || !m.taskType || !Array.isArray(m.taskIds) || !m.taskIds.length) {
+              metrics.push(this._emptyMetric())
+              continue
+            }
+            const taskExists = this.progrTaskSelectOptions.find(o =>
+              o.value.type === m.taskType && o.value.ids[0] === m.taskIds[0]
+            )
+            if (!taskExists) {
+              metrics.push(this._emptyMetric())
+              continue
+            }
+            const taskValue = { type: m.taskType, ids: m.taskIds.slice() }
+            const sigOpts = this.signalOptionsForTaskValue(taskValue)
+            const validSignal = m.signalKey && sigOpts.find(o => o.value === m.signalKey)
+            // If the saved signal is gone but the task has one signal, auto-pick it to mirror the picker UX.
+            const fallback = !validSignal && sigOpts.length === 1 ? sigOpts[0].value : null
+            metrics.push({ taskValue, signalKey: validSignal ? m.signalKey : fallback })
+          }
+          if (!metrics.length) metrics.push(this._emptyMetric())
+          return { id: `slot-${this.nextSlotId++}`, metrics }
+        })
+      } catch {
+        return null
+      }
     }
   }
 }
@@ -402,7 +659,20 @@ export default {
 }
 
 .progression-charts {
-  max-width: 760px;
+  width: 100%;
+}
+
+.slot-wrapper {
+  width: 100%;
+  position: relative;
+  border: 1px solid #d4d8dd;
+  border-radius: 8px;
+  padding: 12px 14px 14px 14px;
+  background: #ffffff;
+}
+
+.metric-row :deep(.q-field__control) {
+  min-height: 36px;
 }
 
 .patient-toolbar {

--- a/src/components/researcher/studymonitor/ParticipantSummaryPage.vue
+++ b/src/components/researcher/studymonitor/ParticipantSummaryPage.vue
@@ -42,8 +42,7 @@
         class="tab-nav-tabs q-px-lg" style="min-height: 56px">
         <q-tab name="progression" icon="ssid_chart" label="Progression" />
         <q-tab name="activity" icon="list_alt" label="Activity Log" />
-        <q-tab name="notes" icon="sticky_note_2" label="Clinical Notes" disable/>
-        <q-tab name="external" icon="link" label="External Systems" disable />
+        <q-tab name="notes" icon="sticky_note_2" label="Clinical Notes" />
       </q-tabs>
     </div>
 

--- a/src/components/researcher/studymonitor/ParticipantSummaryPage.vue
+++ b/src/components/researcher/studymonitor/ParticipantSummaryPage.vue
@@ -40,7 +40,8 @@
     <div class="tab-nav-bar">
       <q-tabs v-model="activeTab" align="left" active-color="secondary" indicator-color="secondary" no-caps
         class="tab-nav-tabs q-px-lg" style="min-height: 56px">
-        <q-tab name="activity" icon="ssid_chart" label="Activity & Progression" />
+        <q-tab name="progression" icon="ssid_chart" label="Progression" />
+        <q-tab name="activity" icon="list_alt" label="Activity Log" />
         <q-tab name="notes" icon="sticky_note_2" label="Clinical Notes" disable />
         <q-tab name="external" icon="link" label="External Systems" disable />
       </q-tabs>
@@ -49,8 +50,8 @@
     <!-- Tab content -->
     <q-tab-panels v-model="activeTab" animated class="tab-panels-bg">
 
-      <!-- Activity & Progression -->
-      <q-tab-panel name="activity" class="q-pa-none">
+      <!-- Progression -->
+      <q-tab-panel name="progression" class="q-pa-none">
 
         <!-- Stats overview cards (customizable, 4 slots) -->
         <div v-if="selectedStatKeys.length" class="q-pa-lg">
@@ -99,56 +100,26 @@
           </div>
         </div>
 
-        <div class="row no-wrap items-start">
-
-          <!-- Left: scrollable activity log -->
-          <div class="col q-pa-md" style="min-width: 0">
-            <q-table title="Activity log" :rows="tasks" selection="none" :columns="columns" row-key="_key"
-              v-model:pagination="pagination" @request="loadTasksSummary" :loading="loadingTasksSummary">
-              <template #body-cell-data="props">
-                <q-td :props="props">
-                  <q-btn v-if="!props.row.discarded" flat icon="open_in_new" @click="showTaskData(props.row)" />
-                </q-td>
-              </template>
-              <template #body-cell-formName="props">
-                <q-td :props="props">
-                  {{ showTaskName(props.row.taskId) }}
-                </q-td>
-              </template>
-              <template #body-cell-completedTS="props">
-                <q-td :props="props">
-                  <div v-if="props.row.discarded">{{ niceTimestamp(props.row.createdTS) }}</div>
-                  <div v-else>{{ niceTimestamp(props.row.summary?.completedTS) }}</div>
-                </q-td>
-              </template>
-              <template #body-cell-summary="props">
-                <q-td :props="props">
-                  <div v-if="props.row.discarded">Discarded</div>
-                  <div v-else v-html="taskSummaryToString(props.row.summary, props.row.taskType)"></div>
-                </q-td>
-              </template>
-            </q-table>
+        <div class="progression-tab-wrapper q-px-lg q-pb-lg">
+          <div class="progression-content">
+            <div class="text-h6 q-mb-sm">Progression</div>
+            <q-select square outlined bg-color="white" v-model="progrSelectedTasks"
+              :options="progrTaskSelectOptions" label="Select task"
+              :popup-content-style="{ maxHeight: '260px' }" />
+            <div v-show="!progrSelectedTasks" class="text-grey-7 q-mt-md">
+              No task selected
+            </div>
+            <div class="progression-charts q-mt-md">
+              <TaskProgressionCharts :studyDescription="studyDescription" :userKey="userKey"
+                :selectedTasks="progrSelectedTasks" />
+            </div>
           </div>
-
-          <!-- Right: progression panel, stays at top -->
-          <div class="col progression-col">
-            <q-card>
-              <q-card-section>
-                <div class="text-h6">Progression</div>
-                <q-select square outlined v-model="progrSelectedTasks" :options="progrTaskSelectOptions"
-                  label="Select task" />
-                <div v-show="!progrSelectedTasks">
-                  No task selected
-                </div>
-                <div>
-                  <TaskProgressionCharts :studyDescription="studyDescription" :userKey="userKey"
-                    :selectedTasks="progrSelectedTasks" />
-                </div>
-              </q-card-section>
-            </q-card>
-          </div>
-
         </div>
+      </q-tab-panel>
+
+      <!-- Activity Log -->
+      <q-tab-panel name="activity" class="q-pa-none">
+        <participant-activity-log :study-key="studyKey" :user-key="userKey" :study-description="studyDescription" />
       </q-tab-panel>
 
       <!-- Clinical Notes — not yet implemented -->
@@ -163,15 +134,10 @@
 import API from '@shared/API.js'
 import { bestLocale } from '@mixins/bestLocale'
 import { taskTypeToString } from '@i18n/utils'
-import { date } from 'quasar'
-
-import AnswersDialog from './taskResultsDialogs/AnswersDialog.vue'
-import DrawingDialog from './taskResultsDialogs/DrawingDialog.vue'
-import FingerTappingDialog from './taskResultsDialogs/FingerTappingDialog.vue'
-import JStyleDialog from './taskResultsDialogs/JStyleDialog.vue'
 
 import TaskProgressionCharts from './TaskProgressionCharts.vue'
 import PatientTrends from './PatientTrends.vue'
+import ParticipantActivityLog from './ParticipantActivityLog.vue'
 
 export default {
   name: 'ParticipantSummaryPage',
@@ -179,22 +145,13 @@ export default {
   mixins: [bestLocale],
   components: {
     TaskProgressionCharts,
-    PatientTrends
+    PatientTrends,
+    ParticipantActivityLog
   },
   data () {
     return {
       participant: {},
       studyDescription: {},
-      // for the summary table:
-      tasks: [],
-      columns: [
-        { name: 'data', required: false, label: '', align: 'center', field: 'data', sortable: false },
-        { name: 'formName', required: true, label: 'Task', align: 'center', field: 'formName' },
-        { name: 'summary', required: true, label: 'Summary', align: 'center', field: 'summary', sortable: false },
-        { name: 'completedTS', required: true, label: 'Completed', align: 'center', field: 'completedTS', sortable: false }
-      ],
-      pagination: { page: 1, rowsPerPage: 20, rowsNumber: 0 },
-      loadingTasksSummary: false,
 
       // for progression charts:
       progrTaskSelectOptions: [],
@@ -208,7 +165,7 @@ export default {
       selectedStatKeys: [],
 
       // tab navigation
-      activeTab: 'activity'
+      activeTab: 'progression'
     }
   },
   computed: {
@@ -286,8 +243,6 @@ export default {
         icon: 'report_problem'
       })
     }
-
-    this.loadTasksSummary()
   },
   methods: {
     onTrendsLoaded ({ allTrendData, availableTrends }) {
@@ -336,130 +291,6 @@ export default {
      */
     closeTab () {
       window.close()
-    },
-    niceTimestamp (timeStamp) {
-      return date.formatDate(timeStamp, 'YYYY-MM-DD HH:mm:ss')
-    },
-    firstLetterUpperCase (str) {
-      return str.charAt(0).toUpperCase() + str.slice(1)
-    },
-    /**
-     * Formats the task name in a readable string
-     */
-    showTaskName (taskId) {
-      const task = this.studyDescription.tasks.find(t => t.id === taskId)
-      if (!task) return 'Unknown task'
-      if (task.customTitle) {
-        return this.getBestLocale(task.customTitle)
-      }
-      const taskType = task.type
-      if (taskType === 'form' && task.formName) return this.getBestLocale(task.formName)
-      return this.firstLetterUpperCase(taskType)
-    },
-    /**
-     * Loads the tasks summary table for that participant
-     */
-    async loadTasksSummary (params) {
-      this.loadingTasksSummary = true
-      if (params) this.pagination = params.pagination
-      const offset = (this.pagination.page - 1) * this.pagination.rowsPerPage
-      const count = this.pagination.rowsPerPage
-      try {
-        const resp = await API.getTasksResults(this.studyKey, this.userKey, null, offset, count)
-        this.tasks = resp.subset
-        this.pagination.rowsNumber = resp.totalCount
-      } catch (err) {
-        this.$q.notify({
-          color: 'negative',
-          message: 'Cannot retrieve tasks',
-          icon: 'report_problem'
-        })
-      }
-      this.loadingTasksSummary = false
-    },
-    /**
-     * Opens a dialog with the task results details
-     */
-    async showTaskData (taskResult) {
-      let component
-      if (taskResult.taskType === 'form') component = AnswersDialog
-      if (taskResult.taskType === 'drawing') component = DrawingDialog
-      if (taskResult.taskType === 'fingerTapping') component = FingerTappingDialog
-      if (taskResult.taskType === 'jstyle') component = JStyleDialog
-      this.$q.dialog({
-        // component loaded into the dialog
-        component,
-        // props forwarded to custom component
-        componentProps: {
-          taskResult,
-          taskName: this.showTaskName(taskResult.taskId)
-        }
-      })
-    },
-    /**
-     * Formats the task summary to a readable string
-     */
-    taskSummaryToString (summary, taskType) {
-      let retString = ''
-      if (taskType === 'form') {
-        retString += 'Answered: ' + summary.answered + ' of ' + summary.asked
-        for (const prop in summary) {
-          if (prop !== 'answered' &&
-            prop !== 'asked' &&
-            prop !== 'startedTS' &&
-            prop !== 'completedTS') {
-            if (typeof summary[prop] === 'string') {
-              retString += '<br>' + this.firstLetterUpperCase(prop) + ': ' + summary[prop]
-            } else if (typeof summary[prop] === 'number') {
-              retString += '<br>' + this.firstLetterUpperCase(prop) + ': ' + summary[prop].toFixed(0)
-            }
-          }
-        }
-      } else if (taskType === 'dataQuery') {
-        retString += 'Type: ' + summary.type
-      } else if (taskType === 'drawing') {
-        retString += 'Square deviation: ' + summary.totalVariabilitySquare.toFixed(0) + '<br>'
-        retString += 'Spiral deviation: ' + summary.totalVariabilitySpiral.toFixed(0) + '<br>'
-      } else if (taskType === 'fingerTapping') {
-        retString += 'Taps count: ' + summary.tappingCount + '<br>'
-      } else if (taskType === 'vocalization') {
-        for (const phase of summary.phases) {
-          const timeDiffSecs = (new Date(phase.completedTS).getTime() - new Date(phase.startedTS).getTime()) / 1000
-          retString += 'Vowel ' + phase.vocal.toUpperCase() + ' : ' + Math.round(timeDiffSecs) + ' sec <br>'
-        }
-      } else if (taskType === 'holdPhone') {
-        retString += 'Resting accel variance L ' + summary.resting.left.accelerationVariance.toFixed(2)
-        retString += ' - R ' + summary.resting.right.accelerationVariance.toFixed(2) + '<br>'
-        retString += 'Postural accel variance L ' + summary.postural.left.accelerationVariance.toFixed(2)
-        retString += ' - R ' + summary.postural.right.accelerationVariance.toFixed(2) + '<br>'
-        retString += 'Kinetic accel variance L ' + summary.postural.left.accelerationVariance.toFixed(2)
-        retString += ' - R ' + summary.kinetic.right.accelerationVariance.toFixed(2)
-      } else if (taskType === 'tugt') {
-        retString += 'Duration: ' + (summary.durationMs / 1000).toFixed(0) + ' sec'
-      } else if (taskType === 'miband3') {
-        retString += 'From: ' + summary.firstTS.slice(0, 10) + ' to: ' + summary.lastTS.slice(0, 10)
-      } else if (taskType === 'peakFlow') {
-        retString += 'PEF Max: ' + summary.pefMax
-      } else if (taskType === 'po60') {
-        retString += 'SPO2: ' + summary.spo2 + ', HR: ' + summary.hr
-      } else if (taskType === 'position') {
-        retString += 'Location: ' + summary.location + '<br>'
-        retString += 'Weather: ' + summary.weather + '<br>'
-        retString += 'Temperature: ' + summary.temperature + '<br>'
-        retString += 'Air quality: ' + summary.aqi
-      } else if (taskType === 'smwt') {
-        retString += 'Distance: ' + summary.distance.toFixed(0) + 'm'
-      } else if (taskType === 'jstyle') {
-        if (summary.activitySummary && summary.activitySummary.length > 0) {
-          for (let i = 0; i < summary.activitySummary.length; i++) {
-            if (i > 0) retString += '<br>'
-            retString += 'Date: ' + summary.activitySummary[i].date.slice(0, 10) + ' - Steps: ' + summary.activitySummary[i].steps
-          }
-        } else {
-          retString += 'From: ' + summary.firstTS.slice(0, 10) + ' to ' + summary.lastTS.slice(0, 10)
-        }
-      }
-      return retString
     }
   }
 }
@@ -565,14 +396,20 @@ export default {
   border-top: 1px solid #f3f4f6;
 }
 
-/* ── Activity / Progression columns ────────────────────────────────── */
-.progression-col {
-  padding: 16px;
-  flex-shrink: 0;
-  width: 480px;
-  position: sticky;
-  top: 66px;
-  align-self: flex-start;
+/* ── Progression tab ───────────────────────────────────────────────── */
+.progression-tab-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.progression-content {
+  width: 100%;
+  max-width: 1100px;
+}
+
+.progression-charts {
+  max-width: 760px;
+  margin: 0 auto;
 }
 
 .patient-toolbar {

--- a/src/components/researcher/studymonitor/TaskProgressionCharts.vue
+++ b/src/components/researcher/studymonitor/TaskProgressionCharts.vue
@@ -1,17 +1,24 @@
 <template>
-  <div v-if="loaded">
-    <div v-for="(dataset, signal) of chartDataSets" :key="signal">
-      <p>{{ chartOptions[signal].description }}</p>
-      <Scatter :data="{ labels, datasets: dataset }" :options="chartOptions[signal]" />
-    </div>
+  <div class="tpc-container">
+    <div v-if="loading" class="tpc-status">Loading…</div>
+    <div v-else-if="unsupported" class="tpc-status">Task type currently unsupported</div>
+    <div v-else-if="!hasRenderable" class="tpc-status">No data to display</div>
+    <Scatter v-else :data="chartData" :options="chartOptions" />
   </div>
-  <h5 v-if="unsupported" style="q-mt-md">Task type currently unsupported</h5>
 </template>
 
 <script>
 import API from '@shared/API.js'
 import { bestLocale } from '@mixins/bestLocale'
 import { taskTypeToString } from '@i18n/utils'
+import { describeSignal, listNumericalSubscales } from './signalCatalog.js'
+import {
+  classifySignal,
+  chartTypeFor,
+  buildDataset,
+  aggregateDailyRange,
+  ChartType
+} from './chartRegistry.js'
 
 import {
   Chart as ChartJS,
@@ -19,6 +26,10 @@ import {
   LinearScale,
   CategoryScale,
   PointElement,
+  LineElement,
+  LineController,
+  BarElement,
+  BarController,
   Title,
   Tooltip,
   Legend
@@ -33,27 +44,44 @@ ChartJS.register(
   LinearScale,
   CategoryScale,
   PointElement,
+  LineElement,
+  LineController,
+  BarElement,
+  BarController,
   Title,
   Tooltip,
   Legend,
   zoomPlugin
 )
 
+// Palette used to colour distinct datasets. The first four are the
+// default metric colours; the extras kick in when a form has many
+// numerical subscales and we render each one as its own line (the
+// __alltrends view). Chosen for strong value-contrast and to remain
+// distinguishable in print or under varying lighting.
 const COLORS = [
-  '#4dc9f6',
-  '#f67019',
-  '#f53794',
-  '#537bc4',
-  '#acc236',
-  '#166a8f',
-  '#00a950',
-  '#58595b',
-  '#8549ba'
+  '#5f8d98', // teal
+  '#c2410c', // deep orange
+  '#b91c1c', // red
+  '#1d4ed8', // blue
+  '#15803d', // green
+  '#7e22ce', // purple
+  '#0891b2', // cyan
+  '#a16207', // amber-dark
+  '#be185d', // pink
+  '#374151' // gray-dark
 ]
 
 export default {
-  name: 'ParticipantSummaryPage',
-  props: ['studyDescription', 'userKey', 'selectedTasks'],
+  name: 'TaskProgressionCharts',
+  props: {
+    studyDescription: { type: Object, required: true },
+    userKey: { type: String, required: true },
+    // { id, metrics: [{ taskValue, signalKey }, ...] }
+    slotConfig: { type: Object, required: true },
+    // taskId -> formDef (preloaded by parent)
+    formDefs: { type: Object, default: () => ({}) }
+  },
   mixins: [bestLocale],
   components: {
     // eslint-disable-next-line vue/no-reserved-component-names
@@ -61,326 +89,444 @@ export default {
   },
   data () {
     return {
-      loaded: false,
+      loading: false,
       unsupported: false,
-      labels: [],
-      chartDataSets: {},
-      chartOptions: {}
+      hasRenderable: false,
+      chartData: { datasets: [] },
+      chartOptions: {},
+      // cacheKey -> { points: [{ date, values }] }
+      taskDataCache: {}
     }
   },
   watch: {
-    /**
-     * Creates the charts for the selected tasks
-     * @param newTasks - array of task ids, all tasks must be of the same type
-     * @param oldTasks - unused
-     */
-    async selectedTasks (newTasks, oldTasks) {
-      this.loaded = false
-      this.unsupported = false
-
+    slotConfig: {
+      deep: true,
+      handler () { this.rebuild() }
+    }
+  },
+  created () { this.rebuild() },
+  methods: {
+    // ── Data fetching ────────────────────────────────────────────────
+    _cacheKey (taskValue) {
+      return `${taskValue.type}:${taskValue.ids.join(',')}`
+    },
+    async fetchTaskData (taskValue) {
+      const key = this._cacheKey(taskValue)
+      if (this.taskDataCache[key]) return this.taskDataCache[key]
       const studykey = this.studyDescription._key
-      // the task type should be the same for all task ids passed
-      // we can just take the first
-      const taskDescr = this.studyDescription.tasks.find(t => t.id === parseInt(newTasks.value.ids[0]))
-      const taskType = taskDescr.type
-      let formDef
-      if (taskType === 'form') {
-        // get the form definition to know which signals to show
-        formDef = await API.getForm(taskDescr.formKey)
-        if (!formDef) {
-          this.unsupported = true
-          return
-        }
-      }
-      const signals = this.getSummarySignalsNames(taskType, formDef)
+      const ids = taskValue.ids
+      const points = []
 
-      if (!signals) {
-        this.unsupported = true
+      if (taskValue.type === 'jstyle') {
+        let inds = []
+        const a = await API.getTaskResultsIndicators(studykey, this.userKey, ids, 'jstyle-activity-daily-stats')
+        if (a) inds = inds.concat(a)
+        const s = await API.getTaskResultsIndicators(studykey, this.userKey, ids, 'jstyle-sleep-daily-stats')
+        if (s) inds = inds.concat(s)
+        inds.sort((x, y) => new Date(x.indicatorsDate) - new Date(y.indicatorsDate))
+        for (const indSet of inds) {
+          points.push({ date: new Date(indSet.indicatorsDate), values: indSet.indicators || {} })
+        }
+      } else {
+        const resp = await API.getTasksResults(studykey, this.userKey, ids)
+        for (const taskRes of resp || []) {
+          if (taskRes.discarded) continue
+          const date = taskRes.summary && taskRes.summary.completedTS
+            ? new Date(taskRes.summary.completedTS)
+            : new Date(taskRes.createdTS)
+          points.push({ date, values: taskRes.summary || {} })
+        }
+        points.sort((x, y) => x.date - y.date)
+      }
+
+      const out = { points }
+      this.taskDataCache[key] = out
+      return out
+    },
+
+    // ── Helpers ──────────────────────────────────────────────────────
+    formDefFor (taskValue) {
+      if (!taskValue || taskValue.type !== 'form') return null
+      return this.formDefs[taskValue.ids[0]] || null
+    },
+    taskLabel (taskValue) {
+      const firstId = taskValue.ids[0]
+      const task = this.studyDescription.tasks && this.studyDescription.tasks.find(t => t.id === parseInt(firstId))
+      if (!task) return 'Task'
+      if (task.customTitle) return this.getBestLocale(task.customTitle)
+      if (taskValue.type === 'form' && task.formName) return this.getBestLocale(task.formName)
+      return taskTypeToString(taskValue.type)
+    },
+    resolveLocale (val) {
+      if (!val) return ''
+      if (typeof val === 'string') return val
+      return this.getBestLocale(val) || ''
+    },
+    extractValue (values, signalKey) {
+      return signalKey.split('.').reduce((p, c) => (p == null ? p : p[c]), values)
+    },
+
+    // ── Main build ───────────────────────────────────────────────────
+    async rebuild () {
+      const metrics = (this.slotConfig && this.slotConfig.metrics ? this.slotConfig.metrics : [])
+        .filter(m => m && m.taskValue && m.signalKey)
+
+      if (!metrics.length) {
+        this.loading = false
+        this.unsupported = false
+        this.hasRenderable = false
         return
       }
 
-      // initialize the dataset for each signal
-      // we keep the same labels for all charts
-      this.labels = []
-      this.chartDataSets = {} // we need an array per signal
-      // table relating the task id -> the dataset index in the datasets array
-      const taskidDatasetIndex = {}
+      this.loading = true
+      this.unsupported = false
+      this.hasRenderable = false
 
-      for (const signal of signals) {
-        // initialise datasets arrays
-        this.chartDataSets[signal] = []
+      try {
+        const primary = metrics[0]
+        const primaryFormDef = this.formDefFor(primary.taskValue)
+        const primaryDesc = describeSignal(primary.taskValue.type, primary.signalKey, primaryFormDef)
+        const primaryChartType = chartTypeFor(classifySignal(primary.taskValue.type, primary.signalKey, primaryDesc))
 
-        // initialise the chart options
-        this.chartOptions[signal] = {
-          responsive: true,
-          // maintainAspectRatio: false,
-          scales: {
-            x: {
-              type: 'time',
-              time: {
-                minUnit: 'minute',
-                unit: 'day',
-                // Luxon format string
-                tooltipFormat: 'DD T'
-              },
-              title: {
-                display: true,
-                text: 'time'
-              }
-            },
-            y: {
-              title: {
-                display: true,
-                text: this.signalToUnitString(signal)
-              }
-            }
-          },
-          plugins: {
-            title: {
-              display: true,
-              text: this.signalToString(signal, formDef),
-              color: '#459399',
-              font: {
-                size: 16
-              }
-            },
-            legend: {
-              display: newTasks.length > 1,
-              position: 'top'
-            }
-          }
-        }
-        this.chartOptions[signal].description = this.signalToDescriptionString(signal, formDef)
-
-        // if the form definition specifies that the signal type is "category"
-        if (formDef && formDef.summaryFunctionDescription &&
-          signal in formDef.summaryFunctionDescription &&
-          formDef.summaryFunctionDescription[signal].type === 'category') {
-          // add the categories to the chart options
-          this.chartOptions[signal].categories = formDef.summaryFunctionDescription[signal].categories
-          // add category options to the y axis
-          this.chartOptions[signal].scales.y = {
-            type: 'category',
-            offset: true,
-            labels: Object.values(formDef.summaryFunctionDescription[signal].categories).map((entry) => this.getBestLocale(entry.name)),
-            title: {
-              display: true,
-              text: this.signalToUnitString(signal)
-            }
-          }
-        }
-      }
-
-      // helper function to find a date in an array of dates
-      function findDateInArray (array, value) {
-        return array.findIndex(item => { return item.getTime() === value.getTime() })
-      }
-
-      // get indicators to show, this depends on the task type
-      if (taskType === 'jstyle') {
-        // retrieve the indicators
-        // studyKey, userKey, taskIds, producer, offset, count
-        let jstyleIndicators = []
-        const dailyActivityIndicators = await API.getTaskResultsIndicators(studykey, this.userKey, newTasks.value.ids, 'jstyle-activity-daily-stats')
-        jstyleIndicators = jstyleIndicators.concat(dailyActivityIndicators)
-        const dailySleepIndicators = await API.getTaskResultsIndicators(studykey, this.userKey, newTasks.value.ids, 'jstyle-sleep-daily-stats')
-        jstyleIndicators = jstyleIndicators.concat(dailySleepIndicators)
-        if (!jstyleIndicators || jstyleIndicators.length === 0) {
-          this.loaded = true
+        // "All subscale trends" takes over the entire slot — overlay
+        // metrics are not visually meaningful here, so the parent page
+        // disables the "add overlay" button for this chart type.
+        if (primaryChartType === ChartType.MULTI_LINE_TRENDS) {
+          await this._buildSymptomTrends(primary, primaryFormDef)
           return
         }
-        // sort by date ascending
-        jstyleIndicators.sort((a, b) => { return (new Date(a.indicatorsDate) - new Date(b.indicatorsDate)) })
 
-        // jstyle indicators can be associated to multiple task ids, but it's meaningless to show multiple times the same datapoint
-        // so we will just pick one task id to associate the datapoint to
-        const taskId = newTasks.value.ids[0]
+        await this._buildStandardChart(metrics)
+      } catch (err) {
+        console.error('TaskProgressionCharts.rebuild failed', err)
+        this.unsupported = true
+        this.loading = false
+      }
+    },
 
-        // now populate the datasets
-        // this.chartDataSets[signal][dataSetIndex] contains all the datapoints for that task/signal
-        // for example, for signal 'steps', dataSetIndex 0 will contain the datapoints for the first task id
-        for (const indicatorSet of jstyleIndicators) {
-          // for each indicator, we need to add its date and the values to the datasets
-          const date = new Date(indicatorSet.indicatorsDate)
-          if (findDateInArray(this.labels, date) === -1) {
-            this.labels.push(date)
-          }
-          for (const signal of signals) {
-            // add the datapoint inside the dataset
-            if (indicatorSet.indicators[signal]) {
-              // as there is only one task id, the dataset index is always 0
-              const dataSetIndex = 0
+    // ── Standard time-axis chart (scatter+line / bar / status / range) ───
+    async _buildStandardChart (metrics) {
+      const datas = await Promise.all(metrics.map(m => this.fetchTaskData(m.taskValue)))
+      const descriptors = metrics.map(m => describeSignal(m.taskValue.type, m.signalKey, this.formDefFor(m.taskValue)))
+      const chartTypes = metrics.map((m, i) => chartTypeFor(classifySignal(m.taskValue.type, m.signalKey, descriptors[i])))
 
-              // initialise the dataset, there is one per signal
-              if (!this.chartDataSets[signal][dataSetIndex]) {
-                this.chartDataSets[signal][dataSetIndex] = {
-                  taskId,
-                  label: 'JStyle Activity Monitor',
-                  borderColor: COLORS[taskId % COLORS.length],
-                  backgroundColor: COLORS[taskId % COLORS.length],
-                  showLine: false,
-                  data: []
-                }
-              }
-
-              // add the signal to the dataset
-              this.chartDataSets[signal][dataSetIndex].data.push(indicatorSet.indicators[signal])
+      // Build points per metric. Range-bar signals aggregate to daily
+      // min/max tuples; everything else is one point per observation.
+      const points = metrics.map((m, i) => {
+        const desc = descriptors[i]
+        if (chartTypes[i] === ChartType.RANGE_BAR) {
+          const baseSignal = desc.rangeBaseSignal || m.signalKey
+          const obs = []
+          for (const p of datas[i].points) {
+            const raw = this.extractValue(p.values, baseSignal)
+            if (typeof raw === 'number' && !Number.isNaN(raw)) {
+              obs.push({ date: p.date, value: raw })
             }
           }
+          return aggregateDailyRange(obs)
+        }
+        const out = []
+        for (const p of datas[i].points) {
+          const raw = this.extractValue(p.values, m.signalKey)
+          if (raw === undefined || raw === null) continue
+          let y = raw
+          if (desc.isCategorical && desc.categories && desc.categories[raw]) {
+            y = this.getBestLocale(desc.categories[raw].name)
+          }
+          out.push({ x: p.date, y })
+        }
+        return out
+      })
+
+      // ── Axis assignment ─────────────────────────────────────────
+      const primaryDesc = descriptors[0]
+      const primaryType = chartTypes[0]
+      const primaryCategorical = primaryDesc.isCategorical
+      const primaryRange = this._numericRange(points[0], primaryType)
+
+      const axisOf = ['y']
+      for (let i = 1; i < metrics.length; i++) {
+        const desc = descriptors[i]
+        const oType = chartTypes[i]
+        if (desc.isCategorical) {
+          if (primaryCategorical && this._sameCategorySet(primaryDesc, desc)) axisOf.push('y')
+          else axisOf.push(null)
+        } else if (primaryCategorical) {
+          axisOf.push('y1')
+        } else if (primaryRange) {
+          const oRange = this._numericRange(points[i], oType)
+          if (!oRange) {
+            axisOf.push('y')
+          } else {
+            const oSpan = Math.max(oRange.max - oRange.min, Math.abs(oRange.max)) || 1
+            const pSpan = Math.max(primaryRange.max - primaryRange.min, Math.abs(primaryRange.max)) || 1
+            const ratio = Math.max(oSpan / pSpan, pSpan / oSpan)
+            axisOf.push(ratio > 5 ? 'y1' : 'y')
+          }
+        } else {
+          axisOf.push('y')
+        }
+      }
+
+      // ── Datasets ────────────────────────────────────────────────
+      const datasets = []
+      for (let i = 0; i < metrics.length; i++) {
+        if (!axisOf[i]) continue
+        if (!points[i].length) continue
+        const desc = descriptors[i]
+        const color = COLORS[i % COLORS.length]
+        const sigLabel = this.resolveLocale(desc.name) || metrics[i].signalKey
+        const taskLabel = this.taskLabel(metrics[i].taskValue)
+        datasets.push(buildDataset({
+          chartType: chartTypes[i],
+          label: `${sigLabel} · ${taskLabel}`,
+          points: points[i],
+          color,
+          yAxisID: axisOf[i]
+        }))
+      }
+
+      if (!datasets.length) {
+        this.hasRenderable = false
+        this.loading = false
+        return
+      }
+
+      // Scales
+      const scales = {
+        x: {
+          type: 'time',
+          time: { minUnit: 'minute', unit: 'day', tooltipFormat: 'DD T' },
+          title: { display: true, text: 'Time' }
+        }
+      }
+      if (primaryCategorical) {
+        scales.y = {
+          type: 'category',
+          offset: true,
+          labels: Object.values(primaryDesc.categories || {}).map(c => this.getBestLocale(c.name)),
+          position: 'left',
+          title: {
+            display: true,
+            text: this.resolveLocale(primaryDesc.unit) || this.resolveLocale(primaryDesc.name),
+            color: COLORS[0]
+          },
+          ticks: { color: COLORS[0] }
         }
       } else {
-        // other task types, use task results summaries to populate the charts
-        const resp = await API.getTasksResults(studykey, this.userKey, newTasks.value.ids)
-
-        // for each task, populate the labels first (the dates)
-        for (const taskRes of resp) {
-          if (!taskRes.discarded) {
-            let date
-            if (taskRes.summary.completedTS) date = new Date(taskRes.summary.completedTS)
-            else date = new Date(taskRes.createdTS)
-            // add the date to the results, so we don't need to recalcuate it later
-            taskRes.date = date
-            // add the label (date) if not already present
-            if (findDateInArray(this.labels, date) === -1) {
-              this.labels.push(date)
-            }
-          }
+        scales.y = {
+          type: 'linear',
+          position: 'left',
+          title: {
+            display: true,
+            text: this.resolveLocale(primaryDesc.unit) || this.resolveLocale(primaryDesc.name),
+            color: COLORS[0]
+          },
+          ticks: { color: COLORS[0] }
         }
+      }
+      const y1Index = axisOf.findIndex((a, i) => i > 0 && a === 'y1')
+      if (y1Index >= 0) {
+        const desc1 = descriptors[y1Index]
+        const c1 = COLORS[y1Index % COLORS.length]
+        scales.y1 = {
+          type: 'linear',
+          position: 'right',
+          grid: { drawOnChartArea: false },
+          title: {
+            display: true,
+            text: this.resolveLocale(desc1.unit) || this.resolveLocale(desc1.name),
+            color: c1
+          },
+          ticks: { color: c1 }
+        }
+      }
 
-        // results are sorted ascending from API, however each task comes with different dates, so we need to re-sort
-        this.labels.sort()
-        // now re-iterate for the datapoints
-        for (const taskRes of resp) {
-          if (!taskRes.discarded) {
-            const taskId = taskRes.taskId
-
-            // get the name of the task
-            let taskName = 'Unknown task'
-            const task = this.studyDescription.tasks.find(t => t.id === parseInt(taskId))
-            if (task.customTitle) {
-              taskName = this.getBestLocale(task.customTitle)
-            } else {
-              if (taskType === 'form' && task.formName) taskName = this.getBestLocale(task.formName)
-              else taskName = taskTypeToString(taskType)
-            }
-
-            // per each "signal" build up an array of datasets, one per taskId
-            // each dataset contains all the datapoints for that task/signal
-            for (const signal of signals) {
-              // get the index this task id has in the sequence of datasets:
-              let dataSetIndex
-              if (taskId in taskidDatasetIndex) {
-                dataSetIndex = taskidDatasetIndex[taskId]
-              } else {
-                // this is a new task we are adding, the index will be the one after the last available one
-                dataSetIndex = this.chartDataSets[signal].length
-                taskidDatasetIndex[taskId] = dataSetIndex
-              }
-
-              // initialise the dataset, there is one per signal and task id
-              if (!this.chartDataSets[signal][dataSetIndex]) {
-                this.chartDataSets[signal][dataSetIndex] = {
-                  taskId,
-                  label: taskName,
-                  borderColor: COLORS[taskId % COLORS.length],
-                  backgroundColor: COLORS[taskId % COLORS.length],
-                  showLine: false,
-                  data: []
+      this.chartData = { datasets }
+      this.chartOptions = {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales,
+        plugins: {
+          legend: { display: true, position: 'top' },
+          tooltip: {
+            // 'x' axis mode picks one item from each dataset at the
+            // hovered x-position. When the user compares two metrics,
+            // the tooltip shows both values side-by-side instead of
+            // only the nearest one.
+            mode: 'x',
+            axis: 'x',
+            intersect: false,
+            callbacks: {
+              // Range bars carry y as [min, max] — format the tooltip
+              // line to read "min – max" instead of the default array repr.
+              label: (ctx) => {
+                const ds = ctx.dataset || {}
+                const raw = ctx.raw || {}
+                if (Array.isArray(raw.y)) {
+                  return `${ds.label}: ${raw.y[0]} – ${raw.y[1]}`
                 }
-              }
-
-              // add the datapoint inside the dataset at the position of the date
-              {
-                // index of the datapoint with respect to its date
-                const Idx = findDateInArray(this.labels, taskRes.date)
-                let value = signal.split('.').reduce((p, c) => p?.[c], taskRes.summary)
-
-                // if the value is a category, we need to convert it to the corresponding label
-                if (this.chartOptions[signal].scales.y.type === 'category') {
-                  value = this.getBestLocale(this.chartOptions[signal].categories[value].name)
-                }
-                this.chartDataSets[signal][dataSetIndex].data[Idx] = value
+                return `${ds.label}: ${ctx.formattedValue}`
               }
             }
           }
-        }
+        },
+        interaction: { mode: 'x', axis: 'x', intersect: false }
+      }
+      this.hasRenderable = true
+      this.loading = false
+    },
+
+    _numericRange (points, chartType) {
+      if (!points || !points.length) return null
+      if (chartType === ChartType.RANGE_BAR) {
+        // Each point's y is [min, max]
+        const mins = points.map(p => Array.isArray(p.y) ? p.y[0] : null).filter(v => typeof v === 'number')
+        const maxes = points.map(p => Array.isArray(p.y) ? p.y[1] : null).filter(v => typeof v === 'number')
+        if (!mins.length || !maxes.length) return null
+        return { min: Math.min(...mins), max: Math.max(...maxes) }
+      }
+      const nums = points.map(p => p.y).filter(v => typeof v === 'number')
+      if (!nums.length) return null
+      return { min: Math.min(...nums), max: Math.max(...nums) }
+    },
+
+    _sameCategorySet (descA, descB) {
+      if (!descA.categories || !descB.categories) return false
+      const a = Object.values(descA.categories).map(c => this.getBestLocale(c.name)).sort().join('|')
+      const b = Object.values(descB.categories).map(c => this.getBestLocale(c.name)).sort().join('|')
+      return a === b
+    },
+
+    // ── All subscales as separate line series ────────────────────────
+    // Expands the form's numerical subscales into one Chart.js dataset
+    // each, all sharing a single time axis.
+    async _buildSymptomTrends (primary, formDef) {
+      const subscaleKeys = listNumericalSubscales(formDef)
+      if (subscaleKeys.length < 2) {
+        this.hasRenderable = false
+        this.loading = false
+        return
+      }
+      const data = await this.fetchTaskData(primary.taskValue)
+      const measurements = data.points || []
+      if (!measurements.length) {
+        this.hasRenderable = false
+        this.loading = false
+        return
       }
 
-      this.loaded = true
-    }
-  },
-  methods: {
-    getDayString (aDate) {
-      aDate = new Date(aDate)
-      const offset = aDate.getTimezoneOffset()
-      aDate = new Date(aDate.getTime() - (offset * 60 * 1000))
-      return aDate.toISOString().split('T')[0]
-    },
-    getSummarySignalsNames (taskType, formDef) {
-      if (taskType === 'form') {
-        if (!formDef) return null
-        if (formDef.summaryFunction && formDef.summaryFunctionDescription) {
-          // if the form definition contains a summary function description, we use it to determine which signals to show
-          return Object.keys(formDef.summaryFunctionDescription)
+      const sorted = [...measurements].sort((a, b) => a.date - b.date)
+      const taskLbl = this.taskLabel(primary.taskValue)
+
+      const datasets = []
+      let maxObserved = 0
+      subscaleKeys.forEach((k, i) => {
+        const desc = describeSignal('form', k, formDef)
+        const pts = []
+        for (const m of sorted) {
+          const v = this.extractValue(m.values, k)
+          if (typeof v !== 'number' || Number.isNaN(v)) continue
+          pts.push({ x: m.date, y: v })
+          if (v > maxObserved) maxObserved = v
         }
+        if (!pts.length) return
+        const color = COLORS[i % COLORS.length]
+        const sigLabel = this.resolveLocale(desc.name) || k
+        const ds = buildDataset({
+          chartType: ChartType.SCATTER_LINE,
+          label: sigLabel,
+          points: pts,
+          color,
+          yAxisID: 'y'
+        })
+        // All trends start hidden — the user opts in by clicking the
+        // legend, which keeps the chart readable on first paint when a
+        // form has 10+ subscales.
+        ds.hidden = true
+        datasets.push(ds)
+      })
+
+      if (!datasets.length) {
+        this.hasRenderable = false
+        this.loading = false
+        return
       }
-      if (taskType === 'tugt') return ['durationMs']
-      if (taskType === 'fingerTapping') return ['tappingCount']
-      if (taskType === 'drawing') return ['totalVariabilitySquare', 'totalVariabilitySpiral']
-      if (taskType === 'holdPhone') return ['resting.left.accelerationVariance', 'resting.right.accelerationVariance', 'postural.left.accelerationVariance', 'postural.right.accelerationVariance', 'kinetic.left.accelerationVariance', 'kinetic.right.accelerationVariance']
-      if (taskType === 'peakFlow') return ['pefMax']
-      if (taskType === 'po60') return ['spo2', 'hr']
-      if (taskType === 'smwt') return ['distance']
-      if (taskType === 'jstyle') return ['steps', 'activeMinutes', 'exerciseMinutes', 'sleepDurationMins']
-    },
-    signalToString (signal, formDef) {
-      if (formDef && formDef.summaryFunctionDescription && signal in formDef.summaryFunctionDescription) {
-        return this.getBestLocale(formDef.summaryFunctionDescription[signal].name)
+
+      // Symptom forms commonly use 0–5 severity scales; anchor the y-axis
+      // to 5 when values fit so charts are visually comparable across
+      // patients. Otherwise round up to the nearest tens for readability.
+      const yMax = maxObserved <= 5 ? 5 : Math.ceil(maxObserved / 10) * 10
+
+      this.chartData = { datasets }
+      this.chartOptions = {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          x: {
+            type: 'time',
+            time: { minUnit: 'minute', unit: 'day', tooltipFormat: 'DD T' },
+            title: { display: true, text: 'Time' }
+          },
+          y: {
+            type: 'linear',
+            position: 'left',
+            // Hard min/max so the chart stays visually stable when every
+            // dataset is hidden (otherwise Chart.js collapses the axis).
+            min: 0,
+            max: yMax,
+            title: { display: true, text: `Score · ${taskLbl}` }
+          }
+        },
+        plugins: {
+          title: {
+            display: true,
+            text: 'Click a subscale name below to show / hide its trend',
+            position: 'top',
+            align: 'center',
+            color: '#6b7280',
+            font: { size: 12, weight: 'normal', style: 'italic' },
+            padding: { top: 2, bottom: 8 }
+          },
+          legend: {
+            display: true,
+            position: 'top',
+            labels: {
+              usePointStyle: true,
+              padding: 12,
+              boxWidth: 8
+            },
+            // Visual affordance — the cursor turns into a pointer when
+            // hovering a legend label so the click interaction is
+            // discoverable.
+            onHover: (e) => {
+              if (e.native && e.native.target) e.native.target.style.cursor = 'pointer'
+            },
+            onLeave: (e) => {
+              if (e.native && e.native.target) e.native.target.style.cursor = 'default'
+            }
+          },
+          tooltip: { mode: 'x', axis: 'x', intersect: false }
+        },
+        interaction: { mode: 'x', axis: 'x', intersect: false }
       }
-      if (signal === 'steps') {
-        return 'Steps'
-      } else if (signal === 'activeMinutes') {
-        return 'Active Minutes'
-      } else if (signal === 'exerciseMinutes') {
-        return 'Exercise Minutes'
-      } else if (signal === 'distance') {
-        return 'Distance'
-      } else if (signal === 'sleepDurationMins') {
-        return 'Sleep Duration'
-      }
-      return signal.charAt(0).toUpperCase() + signal.slice(1)
-    },
-    signalToDescriptionString (signal, formDef) {
-      if (formDef && formDef.summaryFunctionDescription && signal in formDef.summaryFunctionDescription) {
-        return this.getBestLocale(formDef.summaryFunctionDescription[signal].description)
-      }
-      if (signal === 'steps') {
-        return 'Number of steps'
-      } else if (signal === 'activeMinutes') {
-        return 'Number of minutes in light activity'
-      } else if (signal === 'exerciseMinutes') {
-        return 'Number of minutes in exercise activity'
-      } else if (signal === 'distance') {
-        return 'Distance walked'
-      } else if (signal === 'sleepDurationMins') {
-        return 'Duration of sleep in minutes'
-      }
-      return ''
-    },
-    signalToUnitString (signal) {
-      if (signal === 'steps') {
-        return 'steps'
-      } else if (signal === 'activeMinutes') {
-        return 'minutes'
-      } else if (signal === 'exerciseMinutes') {
-        return 'minutes'
-      } else if (signal === 'distance') {
-        return 'meters'
-      } else if (signal === 'sleepDurationMins') {
-        return 'minutes'
-      }
-      return ''
+      this.hasRenderable = true
+      this.loading = false
     }
   }
 }
 </script>
+
+<style scoped>
+.tpc-container {
+  position: relative;
+  width: 100%;
+  height: 320px;
+}
+
+.tpc-status {
+  color: #6b7280;
+  text-align: center;
+  padding: 24px 16px;
+}
+</style>

--- a/src/components/researcher/studymonitor/TaskProgressionCharts.vue
+++ b/src/components/researcher/studymonitor/TaskProgressionCharts.vue
@@ -3,7 +3,23 @@
     <div v-if="loading" class="tpc-status">Loading…</div>
     <div v-else-if="unsupported" class="tpc-status">Task type currently unsupported</div>
     <div v-else-if="!hasRenderable" class="tpc-status">No data to display</div>
-    <Scatter v-else :data="chartData" :options="chartOptions" />
+    <template v-else>
+      <div class="tpc-toolbar">
+        <button type="button" class="tpc-btn" @click="resetZoom" title="Reset zoom" aria-label="Reset zoom">⟲</button>
+      </div>
+      <div class="tpc-chart-wrap">
+        <Scatter ref="chartRef" :data="chartData" :options="chartOptions" />
+      </div>
+      <input
+        type="range"
+        class="tpc-pan-slider"
+        :min="dataXMin || 0"
+        :max="dataXMax || 1"
+        step="any"
+        aria-label="Pan time range"
+        @input="onPanSlider"
+      />
+    </template>
   </div>
 </template>
 
@@ -72,6 +88,18 @@ const COLORS = [
   '#374151' // gray-dark
 ]
 
+// Zoom: slow wheel (default 0.1 is twitchy), x-axis only, locked to the
+// original data range so panning can't drift into empty time.
+const ZOOM_OPTIONS = {
+  pan: { enabled: true, mode: 'x', threshold: 10 },
+  zoom: {
+    wheel: { enabled: true, speed: 0.05 },
+    pinch: { enabled: true },
+    mode: 'x'
+  },
+  limits: { x: { min: 'original', max: 'original', minRange: 60 * 60 * 1000 } }
+}
+
 export default {
   name: 'TaskProgressionCharts',
   props: {
@@ -95,7 +123,10 @@ export default {
       chartData: { datasets: [] },
       chartOptions: {},
       // cacheKey -> { points: [{ date, values }] }
-      taskDataCache: {}
+      taskDataCache: {},
+      // Full time-axis bounds (ms) used as the pan slider's min/max.
+      dataXMin: null,
+      dataXMax: null
     }
   },
   watch: {
@@ -162,6 +193,16 @@ export default {
       if (typeof val === 'string') return val
       return this.getBestLocale(val) || ''
     },
+    // Axis title: "Name (unit)" when both exist, otherwise whichever is
+    // present. Keeps axes self-explanatory when the unit alone (e.g.
+    // "min") would be ambiguous.
+    _axisTitle (desc) {
+      if (!desc) return ''
+      const name = this.resolveLocale(desc.name)
+      const unit = this.resolveLocale(desc.unit)
+      if (name && unit) return `${name} (${unit})`
+      return name || unit || ''
+    },
     extractValue (values, signalKey) {
       return signalKey.split('.').reduce((p, c) => (p == null ? p : p[c]), values)
     },
@@ -181,6 +222,8 @@ export default {
       this.loading = true
       this.unsupported = false
       this.hasRenderable = false
+      this.dataXMin = null
+      this.dataXMax = null
 
       try {
         const primary = metrics[0]
@@ -292,12 +335,14 @@ export default {
         return
       }
 
+      this._setDataRangeFrom(points.flat())
+
       // Scales
       const scales = {
         x: {
           type: 'time',
           time: { minUnit: 'minute', unit: 'day', tooltipFormat: 'DD T' },
-          title: { display: true, text: 'Time' }
+          title: { display: true, text: 'Date' }
         }
       }
       if (primaryCategorical) {
@@ -308,7 +353,7 @@ export default {
           position: 'left',
           title: {
             display: true,
-            text: this.resolveLocale(primaryDesc.unit) || this.resolveLocale(primaryDesc.name),
+            text: this._axisTitle(primaryDesc),
             color: COLORS[0]
           },
           ticks: { color: COLORS[0] }
@@ -319,7 +364,7 @@ export default {
           position: 'left',
           title: {
             display: true,
-            text: this.resolveLocale(primaryDesc.unit) || this.resolveLocale(primaryDesc.name),
+            text: this._axisTitle(primaryDesc),
             color: COLORS[0]
           },
           ticks: { color: COLORS[0] }
@@ -335,7 +380,7 @@ export default {
           grid: { drawOnChartArea: false },
           title: {
             display: true,
-            text: this.resolveLocale(desc1.unit) || this.resolveLocale(desc1.name),
+            text: this._axisTitle(desc1),
             color: c1
           },
           ticks: { color: c1 }
@@ -369,7 +414,8 @@ export default {
                 return `${ds.label}: ${ctx.formattedValue}`
               }
             }
-          }
+          },
+          zoom: ZOOM_OPTIONS
         },
         interaction: { mode: 'x', axis: 'x', intersect: false }
       }
@@ -453,6 +499,8 @@ export default {
         return
       }
 
+      this._setDataRangeFrom(sorted.map(m => ({ x: m.date })))
+
       // Symptom forms commonly use 0–5 severity scales; anchor the y-axis
       // to 5 when values fit so charts are visually comparable across
       // patients. Otherwise round up to the nearest tens for readability.
@@ -466,7 +514,7 @@ export default {
           x: {
             type: 'time',
             time: { minUnit: 'minute', unit: 'day', tooltipFormat: 'DD T' },
-            title: { display: true, text: 'Time' }
+            title: { display: true, text: 'Date' }
           },
           y: {
             type: 'linear',
@@ -506,12 +554,45 @@ export default {
               if (e.native && e.native.target) e.native.target.style.cursor = 'default'
             }
           },
-          tooltip: { mode: 'x', axis: 'x', intersect: false }
+          tooltip: { mode: 'x', axis: 'x', intersect: false },
+          zoom: ZOOM_OPTIONS
         },
         interaction: { mode: 'x', axis: 'x', intersect: false }
       }
       this.hasRenderable = true
       this.loading = false
+    },
+
+    // ── Zoom / pan controls ──────────────────────────────────────────
+    _setDataRangeFrom (points) {
+      let min = Infinity
+      let max = -Infinity
+      for (const p of points) {
+        const t = p.x instanceof Date ? p.x.getTime() : new Date(p.x).getTime()
+        if (Number.isNaN(t)) continue
+        if (t < min) min = t
+        if (t > max) max = t
+      }
+      if (min < max) {
+        this.dataXMin = min
+        this.dataXMax = max
+      }
+    },
+    resetZoom () {
+      const c = this.$refs.chartRef && this.$refs.chartRef.chart
+      if (c) c.resetZoom()
+    },
+    onPanSlider (e) {
+      const c = this.$refs.chartRef && this.$refs.chartRef.chart
+      if (!c) return
+      const x = c.scales.x
+      const span = x.max - x.min
+      const center = Number(e.target.value)
+      let min = center - span / 2
+      let max = center + span / 2
+      if (min < this.dataXMin) { min = this.dataXMin; max = min + span }
+      if (max > this.dataXMax) { max = this.dataXMax; min = max - span }
+      c.zoomScale('x', { min, max })
     }
   }
 }
@@ -521,12 +602,19 @@ export default {
 .tpc-container {
   position: relative;
   width: 100%;
-  height: 320px;
+  height: 380px;
+  display: flex;
+  flex-direction: column;
 }
-
-.tpc-status {
-  color: #6b7280;
-  text-align: center;
-  padding: 24px 16px;
+.tpc-status { color: #6b7280; text-align: center; padding: 24px 16px; }
+.tpc-toolbar { display: flex; justify-content: flex-end; padding-bottom: 4px; }
+.tpc-btn {
+  width: 28px; height: 24px;
+  border: 1px solid #d1d5db; background: #fff; color: #374151;
+  border-radius: 4px; cursor: pointer; padding: 0;
 }
+.tpc-btn:hover { background: #f3f4f6; }
+/* Chart.js needs a sized, positioned parent when maintainAspectRatio is off. */
+.tpc-chart-wrap { position: relative; flex: 1 1 auto; min-height: 0; }
+.tpc-pan-slider { width: 100%; margin-top: 6px; accent-color: #5f8d98; }
 </style>

--- a/src/components/researcher/studymonitor/TaskProgressionCharts.vue
+++ b/src/components/researcher/studymonitor/TaskProgressionCharts.vue
@@ -5,6 +5,8 @@
     <div v-else-if="!hasRenderable" class="tpc-status">No data to display</div>
     <template v-else>
       <div class="tpc-toolbar">
+        <button type="button" class="tpc-btn" @click="zoomIn" title="Zoom in" aria-label="Zoom in">+</button>
+        <button type="button" class="tpc-btn" @click="zoomOut" title="Zoom out" aria-label="Zoom out">−</button>
         <button type="button" class="tpc-btn" @click="resetZoom" title="Reset zoom" aria-label="Reset zoom">⟲</button>
       </div>
       <div class="tpc-chart-wrap">
@@ -577,6 +579,14 @@ export default {
         this.dataXMin = min
         this.dataXMax = max
       }
+    },
+    zoomIn () {
+      const c = this.$refs.chartRef && this.$refs.chartRef.chart
+      if (c) c.zoom({ x: 1.2 })
+    },
+    zoomOut () {
+      const c = this.$refs.chartRef && this.$refs.chartRef.chart
+      if (c) c.zoom({ x: 0.8 })
     },
     resetZoom () {
       const c = this.$refs.chartRef && this.$refs.chartRef.chart

--- a/src/components/researcher/studymonitor/chartRegistry.js
+++ b/src/components/researcher/studymonitor/chartRegistry.js
@@ -1,0 +1,199 @@
+/**
+ * Chart-type registry: maps Mobistudy signals to a default chart type
+ * and produces Chart.js dataset objects with sensible encoding defaults.
+ *
+ */
+
+// Internal taxonomy of data shapes the registry knows about. Not exported
+// because no caller outside this module needs to reason about DataType
+// directly — they go straight from a signal to a ChartType via
+// chartTypeFor(classifySignal(...)).
+const DataType = Object.freeze({
+  // Continuous numerical longitudinal — e.g. PainLevel 0-10, EORTC scores,
+  // weight, peak flow, TUGT duration, drawing variability.
+  CONTINUOUS_NUMERICAL: 'continuous_numerical',
+  // Daily aggregated counts/sums — e.g. jstyle steps, calories,
+  // active/exercise minutes, sleep duration.
+  DAILY_COUNT: 'daily_count',
+  // Categorical state at a point in time — e.g. medication intake
+  // (yes/no/unsure), side effects, treatments.
+  CATEGORICAL_STATE: 'categorical_state',
+  // Several numerical subscales captured together (form has ≥3 numerical
+  // signals). Rendered as one line per subscale over time — a quick
+  // "trend at a glance" view for symptom forms.
+  MULTI_SUBSCALE_TRENDS: 'multi_subscale_trends',
+  // Daily min–max range (multiple readings aggregated per day) — e.g.
+  // po60 HR/SpO2 across a day's measurements.
+  RANGE_MIN_MAX: 'range_min_max'
+})
+
+export const ChartType = Object.freeze({
+  SCATTER_LINE: 'scatter_line',
+  BAR: 'bar',
+  STATUS_TIMELINE: 'status_timeline',
+  MULTI_LINE_TRENDS: 'multi_line_trends',
+  RANGE_BAR: 'range_bar'
+})
+
+const JSTYLE_DAILY_COUNT_SIGNALS = new Set([
+  'steps',
+  'activeMinutes',
+  'exerciseMinutes',
+  'sleepDurationMins'
+])
+
+/**
+ * Decide the DataType for a (taskType, signalKey) pair. `signalDescriptor`
+ * is the output of signalCatalog.describeSignal — used to detect
+ * categorical form signals.
+ */
+export function classifySignal (taskType, signalKey, signalDescriptor) {
+  if (signalDescriptor && signalDescriptor.synthetic === 'alltrends') return DataType.MULTI_SUBSCALE_TRENDS
+  if (signalDescriptor && signalDescriptor.synthetic === 'range') return DataType.RANGE_MIN_MAX
+  if (signalDescriptor && signalDescriptor.isCategorical) {
+    return DataType.CATEGORICAL_STATE
+  }
+  if (taskType === 'jstyle' && JSTYLE_DAILY_COUNT_SIGNALS.has(signalKey)) {
+    return DataType.DAILY_COUNT
+  }
+  return DataType.CONTINUOUS_NUMERICAL
+}
+
+export function chartTypeFor (dataType) {
+  switch (dataType) {
+    case DataType.MULTI_SUBSCALE_TRENDS: return ChartType.MULTI_LINE_TRENDS
+    case DataType.RANGE_MIN_MAX: return ChartType.RANGE_BAR
+    case DataType.DAILY_COUNT: return ChartType.BAR
+    case DataType.CATEGORICAL_STATE: return ChartType.STATUS_TIMELINE
+    case DataType.CONTINUOUS_NUMERICAL:
+    default: return ChartType.SCATTER_LINE
+  }
+}
+
+/**
+ * Convert a #rrggbb color to an rgba() string with the given alpha.
+ * Returns the original string unchanged if it doesn't look like a hex.
+ */
+function withAlpha (hex, alpha) {
+  if (typeof hex !== 'string' || !hex.startsWith('#') || hex.length !== 7) return hex
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}
+
+/**
+ * Build a Chart.js dataset object for one metric.
+ *
+ * `points` are { x: Date, y: number|string } objects. Caller is
+ * responsible for axis assignment (yAxisID) and for already having
+ * converted categorical raw values into category labels.
+ */
+export function buildDataset ({ chartType, label, points, color, yAxisID }) {
+  switch (chartType) {
+    case ChartType.BAR:
+      return {
+        type: 'bar',
+        label,
+        data: points,
+        borderColor: color,
+        // Lower alpha than before so an overlaid line can read against it
+        backgroundColor: withAlpha(color, 0.45),
+        borderWidth: 1.5,
+        borderRadius: 3,
+        // Cap bar width so sparse time series don't render as huge blocks
+        maxBarThickness: 28,
+        yAxisID
+      }
+    case ChartType.RANGE_BAR:
+      // Each point's y is a [min, max] tuple; Chart.js renders a
+      // floating bar between those two values for the given x.
+      return {
+        type: 'bar',
+        label,
+        data: points,
+        borderColor: color,
+        backgroundColor: withAlpha(color, 0.4),
+        borderWidth: 1.5,
+        borderRadius: 3,
+        maxBarThickness: 22,
+        // Guarantees that a day with a single measurement (min == max)
+        // still renders as a visible mark.
+        minBarLength: 4,
+        yAxisID
+      }
+    case ChartType.STATUS_TIMELINE:
+      return {
+        type: 'scatter',
+        label,
+        data: points,
+        borderColor: color,
+        backgroundColor: withAlpha(color, 0.75),
+        showLine: false,
+        pointRadius: 9,
+        pointHoverRadius: 11,
+        pointStyle: 'rectRounded',
+        // White outline so the marker stays readable even when it sits
+        // on top of another dataset's bar or area.
+        pointBorderColor: '#fff',
+        pointBorderWidth: 1.5,
+        borderWidth: 1.5,
+        yAxisID
+      }
+    case ChartType.SCATTER_LINE:
+    default:
+      // type: 'line' (not 'scatter') so the line is drawn by default.
+      // Chart.js v4's ScatterController has showLine: false hard-coded
+      // in its defaults; combined with vue-chartjs's dataset re-use via
+      // Object.assign, the per-dataset showLine: true override can be
+      // lost across re-renders. type: 'line' has lines on by default
+      // and works fine alongside type: 'bar' datasets in the same chart.
+      return {
+        type: 'line',
+        label,
+        data: points,
+        borderColor: color,
+        backgroundColor: color,
+        showLine: true,
+        tension: 0.2,
+        // Larger and outlined points so the dataset is legible against
+        // any underlying bar/area.
+        pointRadius: 5,
+        pointHoverRadius: 8,
+        pointBorderColor: '#fff',
+        pointBorderWidth: 2,
+        borderWidth: 3,
+        yAxisID
+      }
+  }
+}
+
+/**
+ * Aggregate a list of { date, value } observations into daily min–max
+ * tuples, suitable as input to the RANGE_BAR dataset.
+ * Returns [{ x: Date (start of day), y: [min, max] }, ...].
+ */
+export function aggregateDailyRange (observations) {
+  if (!Array.isArray(observations) || !observations.length) return []
+  const byDay = new Map()
+  for (const obs of observations) {
+    if (!obs || obs.value == null || typeof obs.value !== 'number' || Number.isNaN(obs.value)) continue
+    const d = new Date(obs.date)
+    if (Number.isNaN(d.getTime())) continue
+    const dayKey = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
+    const entry = byDay.get(dayKey)
+    if (entry) {
+      if (obs.value < entry.min) entry.min = obs.value
+      if (obs.value > entry.max) entry.max = obs.value
+    } else {
+      byDay.set(dayKey, {
+        x: new Date(d.getFullYear(), d.getMonth(), d.getDate()),
+        min: obs.value,
+        max: obs.value
+      })
+    }
+  }
+  return Array.from(byDay.values())
+    .sort((a, b) => a.x - b.x)
+    .map(e => ({ x: e.x, y: [e.min, e.max] }))
+}

--- a/src/components/researcher/studymonitor/signalCatalog.js
+++ b/src/components/researcher/studymonitor/signalCatalog.js
@@ -1,0 +1,133 @@
+/**
+ * Signal taxonomy shared by ParticipantSummaryPage (signal picker) and
+ * TaskProgressionCharts (chart rendering).
+ *
+ * Pure functions — no Vue, no i18n. `name` and `unit` in describeSignal may
+ * be either plain strings (hardcoded non-form signals) or locale-object
+ * dictionaries straight from a form definition; the caller is responsible
+ * for resolving locale via the bestLocale mixin.
+ */
+
+// Direct signal lists per non-form task type. po60 is handled separately
+// in listSignalsForTask() because it also gets the synthetic __range
+// aliases, so it doesn't appear here.
+const TASK_TYPE_SIGNALS = {
+  tugt: ['durationMs'],
+  fingerTapping: ['tappingCount'],
+  drawing: ['totalVariabilitySquare', 'totalVariabilitySpiral'],
+  holdPhone: [
+    'resting.left.accelerationVariance', 'resting.right.accelerationVariance',
+    'postural.left.accelerationVariance', 'postural.right.accelerationVariance',
+    'kinetic.left.accelerationVariance', 'kinetic.right.accelerationVariance'
+  ],
+  peakFlow: ['pefMax'],
+  smwt: ['distance'],
+  jstyle: ['steps', 'activeMinutes', 'exerciseMinutes', 'sleepDurationMins']
+}
+
+const SIGNAL_DEFAULTS = {
+  steps: { label: 'Steps', unit: 'steps' },
+  activeMinutes: { label: 'Active Minutes', unit: 'min' },
+  exerciseMinutes: { label: 'Exercise Minutes', unit: 'min' },
+  sleepDurationMins: { label: 'Sleep Duration', unit: 'min' },
+  distance: { label: 'Distance', unit: 'm' },
+  durationMs: { label: 'TUGT Duration', unit: 'ms' },
+  tappingCount: { label: 'Tap Count', unit: 'count' },
+  totalVariabilitySquare: { label: 'Drawing Variability (Square)', unit: '' },
+  totalVariabilitySpiral: { label: 'Drawing Variability (Spiral)', unit: '' },
+  pefMax: { label: 'Peak Flow', unit: 'L/min' },
+  spo2: { label: 'SpO2', unit: '%' },
+  hr: { label: 'Heart Rate', unit: 'bpm' }
+}
+
+// Synthetic signal aliases: not real data fields, they tell the chart
+// engine to render a multi-subscale form in a special way.
+//   __alltrends — every numerical subscale as its own line over time
+// Only added when the form has ≥3 numerical subscales.
+const ALLTRENDS_ALIAS = '__alltrends'
+// Suffix for daily min–max range view of a numerical signal (po60).
+const RANGE_SUFFIX = '__range'
+
+function _numericalSubscaleCount (formDef) {
+  if (!formDef || !formDef.summaryFunctionDescription) return 0
+  return Object.values(formDef.summaryFunctionDescription)
+    .filter(sfd => sfd && sfd.type !== 'category')
+    .length
+}
+
+export function listSignalsForTask (taskType, formDef) {
+  if (taskType === 'form') {
+    if (!formDef || !formDef.summaryFunctionDescription) return []
+    const keys = Object.keys(formDef.summaryFunctionDescription)
+    const extras = []
+    // Multi-subscale presentations only make sense with several numerical
+    // subscales (e.g. EORTC QLQ-C30, NCI-PRO-CTCAE).
+    if (_numericalSubscaleCount(formDef) >= 3) {
+      extras.push(ALLTRENDS_ALIAS)
+    }
+    return [...extras, ...keys]
+  }
+  if (taskType === 'po60') {
+    // Per-task summaries are single readings; aggregate into daily
+    // min–max ranges as a separate signal alias.
+    return ['spo2', 'hr', `hr${RANGE_SUFFIX}`, `spo2${RANGE_SUFFIX}`]
+  }
+  return TASK_TYPE_SIGNALS[taskType] || []
+}
+
+export function describeSignal (taskType, signalKey, formDef) {
+  if (signalKey === ALLTRENDS_ALIAS) {
+    return {
+      name: 'All subscales (trends)',
+      unit: '',
+      description: 'Each subscale plotted as its own line over time',
+      isCategorical: false,
+      categories: null,
+      synthetic: 'alltrends'
+    }
+  }
+  if (typeof signalKey === 'string' && signalKey.endsWith(RANGE_SUFFIX)) {
+    const base = signalKey.slice(0, -RANGE_SUFFIX.length)
+    const baseDesc = describeSignal(taskType, base, formDef)
+    return {
+      ...baseDesc,
+      name: typeof baseDesc.name === 'string' ? `${baseDesc.name} (daily range)` : baseDesc.name,
+      description: 'Daily min–max range',
+      synthetic: 'range',
+      rangeBaseSignal: base
+    }
+  }
+  if (taskType === 'form' && formDef && formDef.summaryFunctionDescription && formDef.summaryFunctionDescription[signalKey]) {
+    const sfd = formDef.summaryFunctionDescription[signalKey]
+    const isCategorical = sfd.type === 'category'
+    return {
+      name: sfd.name || signalKey,
+      unit: sfd.unit || '',
+      description: sfd.description || '',
+      isCategorical,
+      categories: isCategorical ? sfd.categories : null
+    }
+  }
+  const def = SIGNAL_DEFAULTS[signalKey]
+  if (def) {
+    return { name: def.label, unit: def.unit, description: '', isCategorical: false, categories: null }
+  }
+  const last = signalKey.split('.').pop()
+  return {
+    name: last.charAt(0).toUpperCase() + last.slice(1),
+    unit: '',
+    description: '',
+    isCategorical: false,
+    categories: null
+  }
+}
+
+/**
+ * Returns the keys of the numerical subscales of a form, used by the
+ * "all subscales (trends)" view when the user picks the __alltrends alias.
+ */
+export function listNumericalSubscales (formDef) {
+  if (!formDef || !formDef.summaryFunctionDescription) return []
+  return Object.keys(formDef.summaryFunctionDescription)
+    .filter(k => formDef.summaryFunctionDescription[k].type !== 'category')
+}


### PR DESCRIPTION
Rebuilt the Progression tab from a single chart into a configurable grid of up to four charts side-by-side. Each chart can show up to two overlaid metrics for direct comparison, with an automatic second y-axis when their scales differ greatly. The chart type is chosen automatically from the data's nature (line, bar, status timeline, daily min–max, or a multi-line view for forms with many subscales). The configuration is persisted per study and patient.

The logic lives in two modules: signalCatalog.js knows which signals exist per task and describes them, while chartRegistry.js maps a signal to the right chart type and builds the Chart.js dataset. TaskProgressionCharts.vue fetches the data and renders; ParticipantSummaryPage.vue manages the grid, pickers, and persistence.